### PR TITLE
fix: add .value to VerboseInformation to access string

### DIFF
--- a/cryptographic_estimators/PKEstimator/PKAlgorithms/sbc.py
+++ b/cryptographic_estimators/PKEstimator/PKAlgorithms/sbc.py
@@ -179,8 +179,8 @@ class SBC(PKAlgorithm):
                 memory = local_memory
 
         if verbose_information is not None:
-            verbose_information[VerboseInformation.SBC_ISD] = c_isd
-            verbose_information[VerboseInformation.SBC_U] = best_u
+            verbose_information[VerboseInformation.SBC_ISD.value] = c_isd
+            verbose_information[VerboseInformation.SBC_U.value] = best_u
 
         return time, memory
 


### PR DESCRIPTION
### Description
- Fixes the frontend bug related to the PKEstimator
- simply adds the ".value" when accessing variables of the VerboseInformation type to output the associated string
