### PR TITLE
fix: display tilde o in table when complexity type 1

### DIFF
--- a/cryptographic_estimators/base_estimator.py
+++ b/cryptographic_estimators/base_estimator.py
@@ -275,6 +275,9 @@ class BaseEstimator(object):
         """
         self.include_tildeo = show_tilde_o_time
         self.include_quantum = show_quantum_complexity
+        if all(self.complexity_type):
+            self.include_tildeo = show_tilde_o_time = True
+
         estimate = self.estimate()
 
         if estimate == {}:


### PR DESCRIPTION
### Description
When complexity type is set to one the table function now always includes the tilde o estimate.