### PR TITLE
Print Verbose Information in `.table()`

### DIFF
--- a/cryptographic_estimators/DummyEstimator/dummy_estimator.py
+++ b/cryptographic_estimators/DummyEstimator/dummy_estimator.py
@@ -40,8 +40,13 @@ class DummyEstimator(BaseEstimator):
                                                                           problem_parameter2=problem_parameter2,
                                                                           memory_bound=memory_bound, **kwargs), **kwargs)
 
-    def table(self, show_quantum_complexity=0, show_tilde_o_time=0,
-              show_all_parameters=0, precision=1, truncate=0):
+    def table(self,
+              show_quantum_complexity=0,
+              show_tilde_o_time=0,
+              show_all_parameters=0,
+              precision=1,
+              truncate=0,
+              show_verbose_information=0):
         """
         Print table describing the complexity of each algorithm and its optimal parameters
 
@@ -52,8 +57,12 @@ class DummyEstimator(BaseEstimator):
         - ``show_all_parameters`` -- show all optimization parameters (default: false)
         - ``precision`` -- number of decimal digits output (default: 1)
         - ``truncate`` -- truncate rather than round the output (default: false)
+        - ``show_verbose_information`` -- show additionally in a new column the `verbose_information` dictionary (default: false)
+
         """
         super(DummyEstimator, self).table(show_quantum_complexity=show_quantum_complexity,
                                           show_tilde_o_time=show_tilde_o_time,
                                           show_all_parameters=show_all_parameters,
-                                          precision=precision, truncate=truncate)
+                                          precision=precision, 
+                                          truncate=truncate,
+                                          show_verbose_information=show_verbose_information)

--- a/cryptographic_estimators/LEEstimator/le_estimator.py
+++ b/cryptographic_estimators/LEEstimator/le_estimator.py
@@ -44,8 +44,13 @@ class LEEstimator(BaseEstimator):
         super(LEEstimator, self).__init__(
             LEAlgorithm, LEProblem(n, k, q, memory_bound=memory_bound, **kwargs), **kwargs)
 
-    def table(self, show_quantum_complexity=0, show_tilde_o_time=0,
-              show_all_parameters=0, precision=1, truncate=0):
+    def table(self,
+              show_quantum_complexity=0,
+              show_tilde_o_time=0,
+              show_all_parameters=0,
+              precision=1,
+              truncate=0,
+              show_verbose_information=0):
         """
         Print table describing the complexity of each algorithm and its optimal parameters
 
@@ -56,6 +61,7 @@ class LEEstimator(BaseEstimator):
         - ``show_all_parameters`` -- show all optimization parameters (default: true)
         - ``precision`` -- number of decimal digits output (default: 1)
         - ``truncate`` -- truncate rather than round the output (default: false)
+        - ``show_verbose_information`` -- show additionally in a new column the `verbose_information` dictionary (default: false)
 
         EXAMPLES::
 
@@ -94,4 +100,6 @@ class LEEstimator(BaseEstimator):
         super(LEEstimator, self).table(show_quantum_complexity=show_quantum_complexity,
                                        show_tilde_o_time=show_tilde_o_time,
                                        show_all_parameters=show_all_parameters,
-                                       precision=precision, truncate=truncate)
+                                       precision=precision,
+                                       truncate=truncate,
+                                       show_verbose_information=show_verbose_information)

--- a/cryptographic_estimators/MQEstimator/mq_estimator.py
+++ b/cryptographic_estimators/MQEstimator/mq_estimator.py
@@ -85,7 +85,13 @@ class MQEstimator(BaseEstimator):
         super(MQEstimator, self).__init__(MQAlgorithm, MQProblem(
             n=n, m=m, q=q, memory_bound=memory_bound, **kwargs), **kwargs)
 
-    def table(self, show_quantum_complexity=0, show_tilde_o_time=0, show_all_parameters=0, precision=1, truncate=0):
+    def table(self,
+              show_quantum_complexity=0,
+              show_tilde_o_time=0,
+              show_all_parameters=0,
+              precision=1,
+              truncate=0,
+              show_verbose_information=0):
         """
         Print table describing the complexity of each algorithm and its optimal parameters
 
@@ -96,6 +102,7 @@ class MQEstimator(BaseEstimator):
         - ``show_all_parameters`` -- show all optimization parameters (default: true)
         - ``precision`` -- number of decimal digits output (default: 1)
         - ``truncate`` -- truncate rather than round the output (default: false)
+        - ``show_verbose_information`` -- show additionally in a new column the `verbose_information` dictionary (default: false)
 
         EXAMPLES::
 
@@ -156,4 +163,6 @@ class MQEstimator(BaseEstimator):
         super(MQEstimator, self).table(show_quantum_complexity=show_quantum_complexity,
                                        show_tilde_o_time=show_tilde_o_time,
                                        show_all_parameters=show_all_parameters,
-                                       precision=precision, truncate=truncate)
+                                       precision=precision,
+                                       truncate=truncate,
+                                       show_verbose_information=show_verbose_information)

--- a/cryptographic_estimators/PEEstimator/pe_estimator.py
+++ b/cryptographic_estimators/PEEstimator/pe_estimator.py
@@ -47,8 +47,13 @@ class PEEstimator(BaseEstimator):
             PEAlgorithm, PEProblem(n, k, q, memory_bound=memory_bound, **kwargs), **kwargs)
 
 
-    def table(self, show_quantum_complexity=0, show_tilde_o_time=0,
-              show_all_parameters=0, precision=1, truncate=0):
+    def table(self,
+              show_quantum_complexity=0,
+              show_tilde_o_time=0,
+              show_all_parameters=0,
+              precision=1,
+              truncate=0,
+              show_verbose_information=0):
         """
         Print table describing the complexity of each algorithm and its optimal parameters
 
@@ -59,6 +64,7 @@ class PEEstimator(BaseEstimator):
         - ``show_all_parameters`` -- show all optimization parameters (default: true)
         - ``precision`` -- number of decimal digits output (default: 1)
         - ``truncate`` -- truncate rather than round the output (default: false)
+        - ``show_verbose_information`` -- show additionally in a new column the `verbose_information` dictionary (default: false)
 
 
         EXAMPLES::
@@ -98,4 +104,6 @@ class PEEstimator(BaseEstimator):
         super(PEEstimator, self).table(show_quantum_complexity=show_quantum_complexity,
                                        show_tilde_o_time=show_tilde_o_time,
                                        show_all_parameters=show_all_parameters,
-                                       precision=precision, truncate=truncate)
+                                       precision=precision,
+                                       truncate=truncate,
+                                       show_verbose_information=show_verbose_information)

--- a/cryptographic_estimators/PKEstimator/pk_estimator.py
+++ b/cryptographic_estimators/PKEstimator/pk_estimator.py
@@ -49,8 +49,13 @@ class PKEstimator(BaseEstimator):
         super(PKEstimator, self).__init__(
             PKAlgorithm, PKProblem(n, m, q, ell=ell, memory_bound=memory_bound, **kwargs), **kwargs)
 
-    def table(self, show_quantum_complexity=0, show_tilde_o_time=0,
-              show_all_parameters=0, precision=1, truncate=0):
+    def table(self, 
+              show_quantum_complexity=0,
+              show_tilde_o_time=0,
+              show_all_parameters=0,
+              precision=1,
+              truncate=0,
+              show_verbose_information=0):
         """
         Print table describing the complexity of each algorithm and its optimal parameters
 
@@ -61,6 +66,7 @@ class PKEstimator(BaseEstimator):
         - ``show_all_parameters`` -- show all optimization parameters (default: true)
         - ``precision`` -- number of decimal digits output (default: 1)
         - ``truncate`` -- truncate rather than round the output (default: false)
+        - ``show_verbose_information`` -- show additionally in a new column the `verbose_information` dictionary (default: false)
 
         EXAMPLES::
 
@@ -94,4 +100,6 @@ class PKEstimator(BaseEstimator):
         super(PKEstimator, self).table(show_quantum_complexity=show_quantum_complexity,
                                        show_tilde_o_time=show_tilde_o_time,
                                        show_all_parameters=show_all_parameters,
-                                       precision=precision, truncate=truncate)
+                                       precision=precision,
+                                       truncate=truncate,
+                                       show_verbose_information=show_verbose_information)

--- a/cryptographic_estimators/SDEstimator/SDAlgorithms/prange.py
+++ b/cryptographic_estimators/SDEstimator/SDAlgorithms/prange.py
@@ -74,6 +74,7 @@ class Prange(SDAlgorithm):
         if verbose_information is not None:
             verbose_information[VerboseInformation.PERMUTATIONS.value] = Tp
             verbose_information[VerboseInformation.GAUSS.value] = Tg
+            verbose_information[VerboseInformation.LISTS.value] = 0
 
         return time, memory
 

--- a/cryptographic_estimators/SDEstimator/sd_estimator.py
+++ b/cryptographic_estimators/SDEstimator/sd_estimator.py
@@ -67,8 +67,13 @@ class SDEstimator(BaseEstimator):
         super(SDEstimator, self).__init__(SDAlgorithm, SDProblem(
             n, k, w, memory_bound=memory_bound, **kwargs), **kwargs)
 
-    def table(self, show_quantum_complexity=0, show_tilde_o_time=0,
-              show_all_parameters=0, precision=1, truncate=0):
+    def table(self, 
+              show_quantum_complexity=0,
+              show_tilde_o_time=0,
+              show_all_parameters=0,
+              precision=1,
+              truncate=0,
+              show_verbose_information=0):
         """
         Print table describing the complexity of each algorithm and its optimal parameters
 
@@ -79,6 +84,7 @@ class SDEstimator(BaseEstimator):
         - ``show_all_parameters`` -- show all optimization parameters (default: true)
         - ``precision`` -- number of decimal digits output (default: 1)
         - ``truncate`` -- truncate rather than round the output (default: false)
+        - ``show_verbose_information`` -- show additionally in a new column the `verbose_information` dictionary (default: false)
 
         EXAMPLES:
 
@@ -168,4 +174,6 @@ class SDEstimator(BaseEstimator):
         super(SDEstimator, self).table(show_quantum_complexity=show_quantum_complexity,
                                        show_tilde_o_time=show_tilde_o_time,
                                        show_all_parameters=show_all_parameters,
-                                       precision=precision, truncate=truncate)
+                                       precision=precision, 
+                                       truncate=truncate,
+                                       show_verbose_information=show_verbose_information)

--- a/cryptographic_estimators/SDFqEstimator/sdfq_estimator.py
+++ b/cryptographic_estimators/SDFqEstimator/sdfq_estimator.py
@@ -44,8 +44,13 @@ class SDFqEstimator(BaseEstimator):
         super(SDFqEstimator, self).__init__(SDFqAlgorithm, SDFqProblem(
             n, k, w, q, memory_bound=memory_bound, **kwargs), **kwargs)
 
-    def table(self, show_quantum_complexity=0, show_tilde_o_time=0,
-              show_all_parameters=0, precision=1, truncate=0):
+    def table(self,
+              show_quantum_complexity=0,
+              show_tilde_o_time=0,
+              show_all_parameters=0,
+              precision=1,
+              truncate=0,
+              show_verbose_information=0):
         """
         Print table describing the complexity of each algorithm and its optimal parameters
 
@@ -56,6 +61,7 @@ class SDFqEstimator(BaseEstimator):
         - ``show_all_parameters`` -- show all optimization parameters (default: true)
         - ``precision`` -- number of decimal digits output (default: 1)
         - ``truncate`` -- truncate rather than round the output (default: false)
+        - ``show_verbose_information`` -- show additionally in a new column the `verbose_information` dictionary (default: false)
 
         EXAMPLES::
 
@@ -88,6 +94,8 @@ class SDFqEstimator(BaseEstimator):
             +-------------+---------+--------+------------------+
         """
         super(SDFqEstimator, self).table(show_quantum_complexity=show_quantum_complexity,
-                                       show_tilde_o_time=show_tilde_o_time,
-                                       show_all_parameters=show_all_parameters,
-                                       precision=precision, truncate=truncate)
+                                         show_tilde_o_time=show_tilde_o_time,
+                                         show_all_parameters=show_all_parameters,
+                                         precision=precision, 
+                                         truncate=truncate,
+                                         show_verbose_information=show_verbose_information)

--- a/cryptographic_estimators/base_estimator.py
+++ b/cryptographic_estimators/base_estimator.py
@@ -245,7 +245,7 @@ class BaseEstimator(object):
                 self.estimates[name] = {}
 
             # used only in the GUI
-            if logger:
+            if logger: 
                 logger(
                     f"[{str(index + 1)}/{str(self.nalgorithms())}] - Processing algorithm: '{name}'")
 
@@ -260,7 +260,13 @@ class BaseEstimator(object):
 
         return self.estimates
 
-    def table(self, show_quantum_complexity=False, show_tilde_o_time=False, show_all_parameters=False, precision=1, truncate=False):
+    def table(self, 
+              show_quantum_complexity=False, 
+              show_tilde_o_time=False, 
+              show_all_parameters=False, 
+              precision=1, 
+              truncate=False,
+              show_verbose_information=True):
         """
         Print table describing the complexity of each algorithm and its optimal parameters
 
@@ -271,6 +277,7 @@ class BaseEstimator(object):
         - ``show_all_parameters`` -- show all optimization parameters (default: false)
         - ``precision`` -- number of decimal digits output (default: 1)
         - ``truncate`` -- truncate rather than round the output (default: false)
+        - ``show_verbose_information`` -- show additionally in a new column the `verbose_information` dictionary (default: false)
 
         """
         self.include_tildeo = show_tilde_o_time
@@ -283,7 +290,7 @@ class BaseEstimator(object):
 
         else:
             renderer = EstimationRenderer(
-                show_quantum_complexity, show_tilde_o_time, show_all_parameters, precision, truncate
+                show_quantum_complexity, show_tilde_o_time, show_all_parameters, precision, truncate, show_verbose_information
             )
             renderer.as_table(estimate)
 

--- a/cryptographic_estimators/estimation_renderer.py
+++ b/cryptographic_estimators/estimation_renderer.py
@@ -116,7 +116,8 @@ class EstimationRenderer():
         ]
 
         # 34 = len("additional_information")
-        table = PrettyTable(table_columns, min_table_width=max(len(sub_table_name), 34))
+        min_table_width = max(len(sub_table_name), 34) if not self._show_verbose_information else len(sub_table_name)
+        table = PrettyTable(table_columns, min_table_width=min_table_width)
         table.padding_width = 1
         table.title = sub_table_name
         if BASE_TIME in table_columns:


### PR DESCRIPTION
### Description
- this PR add the possibility to print the `verbose_information` dict in the estimator `table()` function. E.g. changing the behaviour from:
```
+---------------+---------------------------+
|               |          estimate         |
+---------------+-----------+---------------+
| algorithm     |      time |        memory |
+---------------+-----------+---------------+
| BallCollision |      41.7 |          20.7 |
| BJMMdw        |      41.3 |          25.2 |
| BJMMpdw       |      41.1 |          22.8 |
| BJMM          |      40.8 |          26.0 |
| BJMMplus      |      40.8 |          26.9 |
| BothMay       |      40.4 |          19.0 |
| Dumer         |      40.9 |          25.7 |
| MayOzerov     |      40.3 |          19.0 |
| Prange        |      53.1 |          15.7 |
| Stern         |      40.7 |          20.7 |
+---------------+-----------+---------------+
```
to:
```
+---------------+---------------------------+-------------------------------------------------------------------------------------+
|               |          estimate         |                                additional_information                               |
+---------------+-----------+---------------+--------------+-------+--------------------------------------------------------------+
| algorithm     |      time |        memory | permutations | gauss |                            lists                             |
+---------------+-----------+---------------+--------------+-------+--------------------------------------------------------------+
| BallCollision |      41.7 |          20.7 |     18.4     |  13.6 |           [11.43827205612483, 13.876544112249661]            |
| BJMMdw        |      41.3 |          25.2 |     12.6     |  13.6 | [11.43827205612483, 16.876540927333792, 17.753081854667585]  |
| BJMMpdw       |      41.1 |          22.8 |     11.6     |  13.6 | [11.589182967039351, 14.178353623512892, 28.356707247025785] |
| BJMM          |      40.8 |          26.0 |     11.0     |  13.6 |   [11.8356556908398, 17.67130608996208, 19.34261217992416]   |
| BJMMplus      |      40.8 |          26.9 |     11.0     |  13.6 |  [11.8356556908398, 18.671309545779803, 20.342619091559605]  |
| BothMay       |      40.4 |          19.0 |     15.7     |  13.6 |            [6.22881869049588, 10.457380879072534]            |
| Dumer         |      40.9 |          25.7 |     14.4     |  13.6 |           [16.487478938128476, 16.97495787625695]            |
| MayOzerov     |      40.3 |          19.0 |     15.7     |  13.6 | [6.247927513443585, 10.49585502688717, -165.61736604726397]  |
| Prange        |      53.1 |          15.7 |     31.3     |  13.6 |                             0.0                              |
| Stern         |      40.7 |          20.7 |     15.0     |  13.6 |           [11.43827205612483, 11.876544112249661]            |
+---------------+-----------+---------------+--------------+-------+--------------------------------------------------------------+
```

generated with:
```bash
from cryptographic_estimators.SDEstimator import SDEstimator
SDE = SDEstimator(n=300,k=150,w=38)
SDE.table()
SDE = SDEstimator(n=300,k=150,w=38, show_verbose_information=True)
SDE.table(show_verbose_information=True)
```

### TODOs
- [ ] Currently one needs to pass the `show_verbose_information` to the estimator and the table function? Maybe change this
- [ ] Currently the width of the table must be changed to  `max(len(sub_table_name), 34)` (because `additional_information` is to long)
- [ ] all estimator name the dictionary `verbose_information` but the `base_estimator` calls it `additional_information`, What to choose?
- [ ] add tests
- [ ] check whats happens if TildeO is active

