### PR TITLE
fix: block PR workflow to re-run every time a PR is modified.

### DIFF
--- a/.github/workflows/block-pr.yml
+++ b/.github/workflows/block-pr.yml
@@ -2,6 +2,7 @@ name: block-pr
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, edited]
     branches:
       - main
       - develop


### PR DESCRIPTION
### Description
- Fix Github PR block workflow to re-run if a PR is updated/modified.

### Review process
- Check if workflow success

### Pre-approval checklist
- [x] The code builds clean without any errors or warnings
- [ ] I've added/updated tests
- [ ] I've added/updated documentation if needed
