### PR TITLE
Feature/implement helper sage replacement functions

### DIFF
--- a/cryptographic_estimators/helper.py
+++ b/cryptographic_estimators/helper.py
@@ -15,15 +15,15 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 # ****************************************************************************
 
-
-from math import log2
 from enum import Enum
+from bisect import bisect_left
 
 
 class ComplexityType(Enum):
     """
     distinguish between normal optimisation and tilde O optimisation
     """
+
     ESTIMATE = 0
     TILDEO = 1
 
@@ -43,7 +43,7 @@ def concat_all_tables(tables):
 
 def concat_pretty_tables(t1: str, t2: str):
     """
-    Merge two columns into one 
+    Merge two columns into one
     INPUT:
 
     - ``t1`` -- first column
@@ -68,7 +68,7 @@ def _truncate(x: float, precision: int):
     - ``precision`` -- number of decimial digits to truncate to
 
     """
-    return float(int(x * 10 ** precision) / 10 ** precision)
+    return float(int(x * 10**precision) / 10**precision)
 
 
 def round_or_truncate(x: float, truncate: bool, precision: int):
@@ -82,6 +82,79 @@ def round_or_truncate(x: float, truncate: bool, precision: int):
     - ``precision`` -- number of decimial digits
 
     """
-    val = _truncate(x, precision) if truncate \
-        else round(float(x), precision)
-    return '{:.{p}f}'.format(val, p=precision)
+    val = _truncate(x, precision) if truncate else round(float(x), precision)
+    return "{:.{p}f}".format(val, p=precision)
+
+
+# fmt: off
+PRIMES = [
+    2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71,
+    73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131, 137, 139, 149, 151,
+    157, 163, 167, 173, 179, 181, 191, 193, 197, 199, 211, 223, 227, 229, 233,
+    239, 241, 251, 257, 263, 269, 271, 277, 281, 283, 293, 307, 311, 313, 317,
+    331, 337, 347, 349, 353, 359, 367, 373, 379, 383, 389, 397, 401, 409, 419,
+    421, 431, 433, 439, 443, 449, 457, 461, 463, 467, 479, 487, 491, 499, 503,
+    509, 521, 523, 541, 547, 557, 563, 569, 571, 577, 587, 593, 599, 601, 607,
+    613, 617, 619, 631, 641, 643, 647, 653, 659, 661, 673, 677, 683, 691, 701,
+    709, 719, 727, 733, 739, 743, 751, 757, 761, 769, 773, 787, 797, 809, 811,
+    821, 823, 827, 829, 839, 853, 857, 859, 863, 877, 881, 883, 887, 907, 911,
+    919, 929, 937, 941, 947, 953, 967, 971, 977, 983, 991, 997
+]
+# fmt: on
+
+
+def is_prime_power(n):
+    """
+    Determines if a given number is a power of a prime number.
+
+    INPUT:
+
+    - ``n`` -- The number to be checked.
+    """
+    global PRIMES
+
+    def is_power(n, p):
+        while n % p == 0:
+            n //= p
+        return n == 1
+
+    if n <= 1:
+        return False
+
+    max_prime = PRIMES[-1]
+
+    if n < max_prime:
+        index = bisect_left(PRIMES, n)
+        if index < len(PRIMES) and PRIMES[index] == n:
+            return True
+
+    for prime in PRIMES:
+        if prime * prime > n:
+            return True
+        if n % prime == 0:
+            return is_power(n // prime, prime)
+
+    if max_prime % 6 == 5:
+        prime_candidate = 6 * ((max_prime // 6) + 1) - 1
+        increment = 2
+    else:
+        prime_candidate = 6 * (max_prime // 6) + 1
+        increment = 4
+
+    while prime_candidate * prime_candidate <= n:
+        if n % prime_candidate == 0:
+            return is_power(n // prime_candidate, prime_candidate)
+        prime_candidate += increment
+        increment = 6 - increment
+    return True
+
+
+def is_power_of_two_python(n):
+    """
+    Determines if a given number is a power of two.
+
+    INPUT:
+
+    - ``n`` -- The number to be checked.
+    """
+    return (n & (n - 1) == 0) and n != 0

--- a/cryptographic_estimators/helper.py
+++ b/cryptographic_estimators/helper.py
@@ -21,7 +21,7 @@ from bisect import bisect_left
 
 class ComplexityType(Enum):
     """
-    distinguish between normal optimisation and tilde O optimisation
+    Distinguish between normal optimisation and tilde O optimisation
     """
 
     ESTIMATE = 0
@@ -30,10 +30,12 @@ class ComplexityType(Enum):
 
 def concat_all_tables(tables):
     """
+    Concatenates all tables in a list into a single PrettyTable object.
 
     INPUT:
 
     - ``tables`` -- list of `PrettyTable`
+
     """
     tbl_join = concat_pretty_tables(str(tables[0]), str(tables[1]))
     for i in range(2, len(tables)):
@@ -44,6 +46,7 @@ def concat_all_tables(tables):
 def concat_pretty_tables(t1: str, t2: str):
     """
     Merge two columns into one
+
     INPUT:
 
     - ``t1`` -- first column
@@ -60,7 +63,7 @@ def concat_pretty_tables(t1: str, t2: str):
 
 def _truncate(x: float, precision: int):
     """
-    truncate a value
+    Truncate a value
 
     INPUT:
 
@@ -73,7 +76,7 @@ def _truncate(x: float, precision: int):
 
 def round_or_truncate(x: float, truncate: bool, precision: int):
     """
-    eiter rounds or truncates `x` if `truncate` is `true`
+    Eiter rounds or truncates `x` if `truncate` is `true`
 
     INPUT:
 
@@ -86,6 +89,7 @@ def round_or_truncate(x: float, truncate: bool, precision: int):
     return "{:.{p}f}".format(val, p=precision)
 
 
+# Don't remove this lead and trail comments, they are used for Black.
 # fmt: off
 PRIMES = [
     2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71,
@@ -110,6 +114,27 @@ def is_prime_power(n):
     INPUT:
 
     - ``n`` -- The number to be checked.
+
+    EXAMPLES::
+
+        sage: from cryptographic_estimators.helper import is_prime_power
+        sage: is_prime_power(11)
+        True
+
+    TESTS::
+
+        sage: is_prime_power(557)
+        True
+
+        sage: is_prime_power(7^3+1)
+        False
+
+        sage: is_prime_power(11^4)
+        True
+
+        sage: is_prime_power(1121)
+        False
+
     """
     global PRIMES
 
@@ -149,12 +174,30 @@ def is_prime_power(n):
     return True
 
 
-def is_power_of_two_python(n):
+def is_power_of_two(n):
     """
     Determines if a given number is a power of two.
 
     INPUT:
 
     - ``n`` -- The number to be checked.
+
+    EXAMPLES::
+
+        sage: from cryptographic_estimators.helper import is_power_of_two
+        sage: is_power_of_two(16)
+        True
+
+    TESTS::
+
+        sage: is_power_of_two(2^15)
+        True
+
+        sage: is_power_of_two(21)
+        False
+
+        sage: is_power_of_two(33554432)
+        True
+
     """
     return (n & (n - 1) == 0) and n != 0


### PR DESCRIPTION
### Description

**Main changes**

Python implementation of the `is_prime_power` and `is_power_of_two`functions, which will replace its homonymous Sage functions.

- `is_power_of_two`

  - Uses bitwise operations for faster computations.

  - Performance changes over Sage: 7x faster.

- `is_prime_power`

  -  Uses a precomputed list for small inputs, and uses numbers with the shape $6k\pm 1$ (prime candidates) to check divisibility on larger inputs.

  - Performance changes over Sage:

    - On inputs in the range of the precomputed primes: Same performance.

    - On larger inputs: About 1.5 times slower than Sage. This is a natural implication when comparing a Python function versus a C function from a highly optimized library (such as the one used by Sage, via the **PARI** library).

**Minor changes**

- Stylistic changes via Black.
- Remove one unused import.

### Review process

- **Feedback needed:** Do you agree to put this kind of functions in the `helper.py` file, or should I create a new file for that?
- Functions have been already intensively tested on my side.

### Pre-approval checklist
- [x] The code builds clean without any errors or warnings
- [ ] I've added/updated tests
- [x] I've added/updated documentation if needed
