### PR TITLE
Fix/remove undesirable pytest prints

### DIFF
--- a/tests/test_le_bbps.sage
+++ b/tests/test_le_bbps.sage
@@ -1,16 +1,17 @@
-import random
 from cryptographic_estimators.LEEstimator.LEAlgorithms import *
 from cryptographic_estimators.LEEstimator import LEProblem
-from cryptographic_estimators.SDFqEstimator.SDFqAlgorithms import LeeBrickell, Prange, Stern
+from cryptographic_estimators.SDFqEstimator.SDFqAlgorithms import LeeBrickell, Prange
 
-from math import inf
-load('tests/module/cost.sage')
-bbps_params = {"bit_complexities": 1, "sd_parameters": { "excluded_algorithms": [Prange, LeeBrickell]} }
+load("tests/module/cost.sage")
+bbps_params = {
+    "bit_complexities": 1,
+    "sd_parameters": {"excluded_algorithms": [Prange, LeeBrickell]},
+}
 
 
 def test_bbps1():
     """
-    special value test
+    Special value test.
     """
     n = 200
     k = 100
@@ -22,45 +23,43 @@ def test_bbps1():
             ranges = 1
         A = BBPS(LEProblem(n, k, q), **bbps_params)
         t1 = A.time_complexity()
-        t2, w, w_prime, L_prime = improved_linear_beullens(n, k, q)
-
-        # if not (t2 - ranges< t1 < t2 + ranges):
-        # print(n, k, q, t1, t2)
+        t2, _, _, _ = improved_linear_beullens(n, k, q)
 
         assert t2 - ranges < t1 < t2 + ranges
 
 
 # We use an approximation of the coupon collector for efficiency reasons leading to small deviations for small instances
-def correct_coupon_collector(L_prime,Nw_prime):
+def correct_coupon_collector(L_prime, Nw_prime):
     if L_prime > Nw_prime - 1:
-        L_prime= 2^L_prime
-        Nw_prime=2^Nw_prime
+        L_prime = 2 ^ L_prime
+        Nw_prime = 2 ^ Nw_prime
         #      ____________________Approximation_________________   _________________Coupon Collector___________________________
-        return (log2(L_prime)-log2(Nw_prime)+log2(log2(L_prime))) - log2(2*log(1.-L_prime/Nw_prime)/log(1.-1/Nw_prime)/Nw_prime)
+        return (log2(L_prime) - log2(Nw_prime) + log2(log2(L_prime))) - log2(
+            2 * log(1.0 - L_prime / Nw_prime) / log(1.0 - 1 / Nw_prime) / Nw_prime
+        )
     return 0
 
 
 def test_bbps2():
     """
-    generic test
+    Generic test.
     """
     ranges = 0.2
 
-
-    for n in range(100, 120,5):
-        for k in range(n//2,n//2+10,2):
+    for n in range(100, 120, 5):
+        for k in range(n // 2, n // 2 + 10, 2):
             for q in [7, 11, 17, 31]:
                 A = BBPS(LEProblem(n, k, q), **bbps_params)
                 t1 = A.time_complexity()
-                t2, w, w_prime, L_prime = improved_linear_beullens(n, k, q)
+                t2, _, _, _ = improved_linear_beullens(n, k, q)
 
                 if t2 == 100000000000000:
                     continue
 
                 verb = A._get_verbose_information()
-                L,N= verb["L_prime"],verb["Nw_prime"]
+                L, N = verb["L_prime"], verb["Nw_prime"]
 
-                t2 += correct_coupon_collector(L,N)
+                t2 += correct_coupon_collector(L, N)
                 assert t2 - ranges < t1 < t2 + ranges
 
 

--- a/tests/test_pe.sage
+++ b/tests/test_pe.sage
@@ -1,24 +1,27 @@
-from cryptographic_estimators.SDFqEstimator.SDFqAlgorithms import LeeBrickell, Prange, Stern
+from cryptographic_estimators.SDFqEstimator.SDFqAlgorithms import Prange, Stern
 from cryptographic_estimators.PEEstimator.PEAlgorithms import Leon, Beullens
 from cryptographic_estimators.PEEstimator import PEProblem
-from cryptographic_estimators.PEEstimator.pe_helper import number_of_weight_d_codewords, gv_distance
 
 
-load('tests/module/attack_cost.sage')
-load('tests/module/cost.sage')
+load("tests/module/attack_cost.sage")
+load("tests/module/cost.sage")
 
 # global parameters
-leon_params = {"bit_complexities": 0, "sd_parameters": {"excluded_algorithms": [Prange, Stern]}}
+leon_params = {
+    "bit_complexities": 0,
+    "sd_parameters": {"excluded_algorithms": [Prange, Stern]},
+}
+
 
 # correction term due to correction of the LeeBrickell procedure, see SDFqAlgorithms/leebrickell.py line 98/99
 def lee_brickell_correction(k):
-    return log(k, 2)*2 - log(binomial(k, 2), 2)
+    return log(k, 2) * 2 - log(binomial(k, 2), 2)
 
 
 def test_leon1():
     """
     test some hardcoded values taken from:
-       https://github.com/WardBeullens/LESS_Attack/blob/master/attack_cost.py 
+       https://github.com/WardBeullens/LESS_Attack/blob/master/attack_cost.py
     """
 
     n, k, q = 250, 125, 53
@@ -41,12 +44,11 @@ def test_leon2():
        https://github.com/WardBeullens/LESS_Attack/blob/master/attack_cost.py
     """
     ranges = 0.01
-    n, k= 250, 150
+    n, k = 250, 150
     q_values = [11, 17, 53, 103, 151, 199, 251]
     for q in q_values:
         t1 = LEON(n, k, q) + log2(n) - lee_brickell_correction(k)
         t2 = Leon(PEProblem(n, k, q), **leon_params).time_complexity()
-        print(n,k,q,t1,t2)
         assert t1 - ranges <= t2 <= t1 + ranges
 
 
@@ -57,18 +59,19 @@ def test_leon():
     # for small values due to rounding issues we have to slightly increase the tolerance
     ranges = 0.2
     for n in range(50, 100, 5):
-        for k in range(n//2, n//2+5):
+        for k in range(n // 2, n // 2 + 5):
             for q in [3, 7, 17, 31]:
                 A = Leon(PEProblem(n, k, q), **leon_params)
 
                 # due to slightly different calculation of "number_of_weight_d_codewords" optimal w might differ by 1
                 # for some edge cases
                 t11 = A.time_complexity()
-                t12 = A.time_complexity(w=A.optimal_parameters()["w"]-1)
+                t12 = A.time_complexity(w=A.optimal_parameters()["w"] - 1)
 
                 t2 = LEON(n, k, q) + log2(n) - lee_brickell_correction(k)
-                # print(n, k, q, t11, t12, t2)
-                assert t2 - ranges < t11 < t2 + ranges or t2 - ranges < t12 < t2 + ranges
+                assert (
+                    t2 - ranges < t11 < t2 + ranges or t2 - ranges < t12 < t2 + ranges
+                )
 
 
 def test_beullens():
@@ -81,28 +84,28 @@ def test_beullens():
     ranges = 0.01
     ts = []
     ts2 = []
-    for i in range(10):
-        ts.append(attack_cost(n, k, q, False, False) + log(n, 2) - lee_brickell_correction(k))
+    for _ in range(10):
+        ts.append(
+            attack_cost(n, k, q, False, False) + log(n, 2) - lee_brickell_correction(k)
+        )
         A = Beullens(PEProblem(n, k, q), **leon_params)
         ts2.append(A.time_complexity())
     t1 = min(ts)
     t2 = min(ts2)
-    print(t2, t1, A.optimal_parameters())
     assert t1 - ranges <= t2 <= t1 + ranges
-
 
     n, k, q = 106, 45, 7
     ts = []
     ts2 = []
-    for i in range(10):
-        ts.append(attack_cost(n, k, q, False, False) + log(n, 2) - lee_brickell_correction(k))
+    for _ in range(10):
+        ts.append(
+            attack_cost(n, k, q, False, False) + log(n, 2) - lee_brickell_correction(k)
+        )
         A = Beullens(PEProblem(n, k, q), **leon_params)
         ts2.append(A.time_complexity())
     t1 = min(ts)
     t2 = min(ts2)
-    print(t2, t1, A.optimal_parameters())
     assert t1 - ranges <= t2 <= t1 + ranges
-
 
 
 if __name__ == "__main__":

--- a/tests/test_pk.sage
+++ b/tests/test_pk.sage
@@ -1,20 +1,25 @@
 from cryptographic_estimators.PKEstimator import PKProblem
 from cryptographic_estimators.PKEstimator.PKAlgorithms import KMP, SBC
 from cryptographic_estimators.SDFqEstimator.SDFqAlgorithms import Prange, LeeBrickell
-load('tests/module/cost.sage')
-load('tests/module/kmp_cost.sage')
-load('tests/module/our_cost.sage')
+
+load("tests/module/cost.sage")
+load("tests/module/kmp_cost.sage")
+load("tests/module/our_cost.sage")
 
 
 # global parameters
-params = {"bit_complexities": False, "cost_for_list_operation": 1, "memory_for_list_element": 1,
-          "sd_parameters": {"excluded_algorithms": [Prange, LeeBrickell]}}
+params = {
+    "bit_complexities": False,
+    "cost_for_list_operation": 1,
+    "memory_for_list_element": 1,
+    "sd_parameters": {"excluded_algorithms": [Prange, LeeBrickell]},
+}
 ranges = 0.1
 
 
 def test_kmp():
     """
-    special value test
+    Special value test
     """
     n = 94
     m = 55
@@ -25,9 +30,10 @@ def test_kmp():
     _, _, _, _, _, t2 = kmp_cost_numerical(n, m, ell, q)
     assert t1 - ranges <= t2 <= t1 + ranges
 
+
 def test_sbc():
     """
-    special value test
+    Special value test
     """
     n = 94
     m = 55
@@ -42,14 +48,14 @@ def test_sbc():
 
 def test_kmp_range():
     """
-    small value test
+    Small value test
     """
     # we adapted the KMP algorithm to allow to enumerate on m.
     for n in range(30, 100):
         for m in range(int(0.3 * n), int(0.7 * n)):
             for ell in range(1, 2):
                 for q in [7, 11, 17, 53, 103, 151, 199, 251]:
-                    if q^ell < n:
+                    if q ^ ell < n:
                         continue
                     A = KMP(PKProblem(n, m, q, ell), **params)
                     t1 = A.time_complexity()
@@ -60,20 +66,17 @@ def test_kmp_range():
 
 def test_sbc_range():
     """
-    small value test
+    Small value test
     """
 
-    for n in range(30, 50,5):
-        for m in range(n//2, n//2 + 5):
-            for ell in range(1,3):
-                for q in [ 53, 151, 251]:
-                    if q^ell < n:
+    for n in range(30, 50, 5):
+        for m in range(n // 2, n // 2 + 5):
+            for ell in range(1, 3):
+                for q in [53, 151, 251]:
+                    if q ^ ell < n:
                         continue
-
                     t1 = SBC(PKProblem(n, m, q, ell), **params).time_complexity()
                     _, _, _, _, _, t2 = compute_new_cost(n, m, q, ell)
-
-                    print(n, m, q, ell, t1, t2)
                     assert t2 - ranges < t1 < t2 + ranges
 
 

--- a/tests/test_sdfq.sage
+++ b/tests/test_sdfq.sage
@@ -1,61 +1,69 @@
-from cryptographic_estimators.SDFqEstimator import SDFqEstimator
 from cryptographic_estimators.SDFqEstimator.SDFqAlgorithms import *
 from cryptographic_estimators.SDFqEstimator import SDFqProblem
-from math import  floor, log2, ceil, comb, comb as binomial, log2 as log
+from math import comb as binomial, log2 as log
 
 
-load('tests/module/attack_cost.sage')
-load('tests/module/cost.sage')
+load("tests/module/attack_cost.sage")
+load("tests/module/cost.sage")
 
 
 # global parameters
 params = {"bit_complexities": 0, "is_syndrome_zero": True, "nsolutions": 0}
 stern_params = {"bit_complexities": 1, "is_syndrome_zero": True, "nsolutions": 0}
 
+
 # correction term due to correction of the LeeBrickell procedure, see SDFqAlgorithms/leebrickell.py line 98/99
 def lee_brickell_correction(k):
-    return log(k, 2)*2 - log(binomial(k, 2), 2)
+    return log(k, 2) * 2 - log(binomial(k, 2), 2)
 
 
 def test_sdfq_LeeBrickell():
     """
-    special value test for Lee-Brickell
+    Special value test for Lee-Brickell
     """
     # we need to subtract the difference of lee brickell
     # and p = 1, because p = 2 is not always optimial
     ranges = 0.01
     n, k, w, q = 256, 128, 64, 251
-    t1 = log(ISD_COST(n, k, w, q), 2) + log(n,2) - lee_brickell_correction(k)
+    t1 = log(ISD_COST(n, k, w, q), 2) + log(n, 2) - lee_brickell_correction(k)
     A = LeeBrickell(SDFqProblem(n, k, w, q, **params), **params)
     t2 = A.time_complexity(p=2)
-    assert(t1 - ranges < t2 < t1 + ranges)
+    assert t1 - ranges < t2 < t1 + ranges
 
     n, k, w, q = 961, 771, 48, 31
-    t1 = log(ISD_COST(n, k, w, q), 2) + log(n,2) - lee_brickell_correction(k)
+    t1 = log(ISD_COST(n, k, w, q), 2) + log(n, 2) - lee_brickell_correction(k)
     A = LeeBrickell(SDFqProblem(n, k, w, q, **params), **params)
     t2 = A.time_complexity(**{"p": 2})
-    assert(t1 - ranges < t2 < t1 + ranges)
+    assert t1 - ranges < t2 < t1 + ranges
 
 
 def test_sdfq_stern():
     """
-    special value test for Stern
+    Special value test for Stern
     """
     ranges = 0.01
     n, k, w, q = 256, 128, 64, 251
-    t, p, l = peters_isd(n, k, q, w)
-    t1 = Stern(SDFqProblem(n, k, w, q, **stern_params), **stern_params).time_complexity()
-    assert(t - ranges < t1 < t + ranges)
+    t, _, _ = peters_isd(n, k, q, w)
+    t1 = Stern(
+        SDFqProblem(n, k, w, q, **stern_params), **stern_params
+    ).time_complexity()
+    assert t - ranges < t1 < t + ranges
 
-    n, k, w, q = 961, 771, 48,31
-    t, p, l = peters_isd(n, k, q, w)
+    n, k, w, q = 961, 771, 48, 31
+    t, _, _ = peters_isd(n, k, q, w)
 
-    assert(t - ranges < Stern(SDFqProblem(n, k, w, q, **stern_params), **stern_params).time_complexity() < t + ranges)
+    assert (
+        t - ranges
+        < Stern(
+            SDFqProblem(n, k, w, q, **stern_params), **stern_params
+        ).time_complexity()
+        < t + ranges
+    )
 
 
 def test_sdfq_stern_range():
     """
-    range test for Stern
+    Range test for Stern
     """
     ranges = 0.05
 
@@ -63,14 +71,11 @@ def test_sdfq_stern_range():
         for k in range(20, 40, 2):
             for w in range(4, min(n - k - 1, int(0.5 * n))):
                 for q in [7, 11, 17, 53, 103, 151, 199, 251]:
-                    A=Stern(SDFqProblem(n, k, w, q, **stern_params), **stern_params)
+                    A = Stern(SDFqProblem(n, k, w, q, **stern_params), **stern_params)
                     # peters_isd comparison code restricts l to this range
-                    A.set_parameter_ranges("l", 1, n-k)
+                    A.set_parameter_ranges("l", 1, n - k)
                     t1 = A.time_complexity()
-                    print(A.optimal_parameters())
-                    t2, p, l = peters_isd(n, k, q, w)
-
-                    print(n,k,q,w,t1,t2)
+                    t2, _, _ = peters_isd(n, k, q, w)
                     assert t2 - ranges < t1 < t2 + ranges
 
 
@@ -78,3 +83,4 @@ if __name__ == "__main__":
     test_sdfq_LeeBrickell()
     test_sdfq_stern()
     test_sdfq_stern_range()
+


### PR DESCRIPTION
### Description
- Remove all the debugging prints that ended up in the pytest tests code, and made the output very hard to read.
- I also made small refactor to improve the style of the code.

### Review process
- You can switch to this branch and execute `make docker-pytest` to see the new cleaner output.

### Pre-approval checklist
- [x] The code builds clean without any errors or warnings
- [x] I've added/updated tests
- [x] I've added/updated documentation if needed
