### PR TITLE
Refactor/hilbert series with flint

### DIFF
--- a/cryptographic_estimators/MQEstimator/MQAlgorithms/crossbred.py
+++ b/cryptographic_estimators/MQEstimator/MQAlgorithms/crossbred.py
@@ -157,13 +157,13 @@ class Crossbred(MQAlgorithm):
 
     def _ncols_in_preprocessing_step(self, k: int, D: int, d: int):
         """
-         Return the number of columns involve in the preprocessing step
+        Return the number of columns involve in the preprocessing step
 
-         INPUT:
+        INPUT:
 
-         - ``k`` -- no. variables in the resulting system
-         - ``D`` -- degree of the initial Macaulay matrix
-         - ``d`` -- degree resulting Macaulay matrix
+        - ``k`` -- no. variables in the resulting system
+        - ``D`` -- degree of the initial Macaulay matrix
+        - ``d`` -- degree resulting Macaulay matrix
 
         TESTS::
 
@@ -196,12 +196,12 @@ class Crossbred(MQAlgorithm):
 
     def _ncols_in_linearization_step(self, k: int, d: int):
         """
-         Return the number of columns involve in the linearization step
+        Return the number of columns involve in the linearization step
 
-         INPUT:
+        INPUT:
 
-         - ``k`` -- no. variables in the resulting system
-         - ``d`` -- degree resulting Macaulay matrix
+        - ``k`` -- no. variables in the resulting system
+        - ``d`` -- degree resulting Macaulay matrix
 
         TESTS::
 
@@ -216,10 +216,20 @@ class Crossbred(MQAlgorithm):
     def _C(self, parameters: dict):
         """ """
         k, D, d = parameters["k"], parameters["D"], parameters["d"]
-        n, m, q, max_D = parameters["n"], parameters["m"], parameters["q"], parameters["max_D"]
+        n, m, q, max_D = (
+            parameters["n"],
+            parameters["m"],
+            parameters["q"],
+            parameters["max_D"],
+        )
         Hk = HilbertSeries(n=k, degrees=[2] * m, q=q)
         N = NMonomialSeries(n=n - k, q=q, max_prec=max_D + 1)
-        out = sum([Hk.coefficient_of_degree(i) * N.nmonomials_of_degree(D - i) for i in range(d + 1)])
+        out = sum(
+            [
+                Hk.coefficient_of_degree(i) * N.nmonomials_of_degree(D - i)
+                for i in range(d + 1)
+            ]
+        )
         return out
 
     def _valid_choices(self):
@@ -255,11 +265,16 @@ class Crossbred(MQAlgorithm):
                 for d in range(1, min(h_k_d_reg, D)):
                     C_D_d = sum(
                         [
-                            Hk.coefficient_of_degree(i) * N.nmonomials_up_to_degree(D - i)
+                            Hk.coefficient_of_degree(i)
+                            * N.nmonomials_up_to_degree(D - i)
                             for i in range(d + 1)
                         ]
                     )
-                    coefficient_D_d = C_D_d - Hn.coefficient_up_to_degree(D) - Hk.coefficient_up_to_degree(d)
+                    coefficient_D_d = (
+                        C_D_d
+                        - Hn.coefficient_up_to_degree(D)
+                        - Hk.coefficient_up_to_degree(d)
+                    )
                     if (
                         0 <= coefficient_D_d
                         and new_ranges["D"]["min"] <= D <= new_ranges["D"]["max"]

--- a/cryptographic_estimators/MQEstimator/degree_of_regularity.py
+++ b/cryptographic_estimators/MQEstimator/degree_of_regularity.py
@@ -131,7 +131,7 @@ def semi_regular_system(n: int, degrees: list[int], q=None):
             "the number of polynomials must be >= than the number of variables")
 
     s = HilbertSeries(n, degrees, q=q)
-    return s.first_nonpositive_integer()
+    return s.first_nonpositive_coefficient()
 
 
 def quadratic_system(n: int, m: int, q=None):

--- a/cryptographic_estimators/MQEstimator/series/hilbert.py
+++ b/cryptographic_estimators/MQEstimator/series/hilbert.py
@@ -65,6 +65,36 @@ class HilbertSeries(object):
         self._series_up_to_degree = self._series / (1 - x)
 
     @property
+    def _hilbert_serie(self):
+        """
+        Return the representation of the _series attribute.
+
+        EXAMPLES::
+
+            sage: from cryptographic_estimators.MQEstimator.series.hilbert import HilbertSeries
+            sage: H = HilbertSeries(5, [2]*7)
+            sage: H._hilbert_serie
+            1 + 5*x + 8*x^2 + (-14)*x^4 + (-14)*x^5 + 8*x^7 + 5*x^8 + x^9 + O(x^14)
+
+        """
+        return self._series
+
+    @property
+    def _hilbert_serie_up_to_degree(self):
+        """
+        Return the representation of the _series_up_to_degree attribute.
+
+        EXAMPLES::
+
+            sage: from cryptographic_estimators.MQEstimator.series.hilbert import HilbertSeries
+            sage: H = HilbertSeries(5, [2]*7)
+            sage: H._hilbert_serie_up_to_degree
+            1 + 6*x + 14*x^2 + 14*x^3 + (-14)*x^5 + (-14)*x^6 + (-6)*x^7 + (-1)*x^8 + O(x^14)
+
+        """
+        return self._series_up_to_degree
+
+    @property
     def nvariables(self):
         """
         Return the no. of variables

--- a/cryptographic_estimators/MQEstimator/series/hilbert.py
+++ b/cryptographic_estimators/MQEstimator/series/hilbert.py
@@ -23,7 +23,7 @@ from math import prod
 
 class HilbertSeries(object):
     """
-    Construct an instance of Hilbert series
+    Construct an instance of Hilbert series.
 
     INPUT:
 
@@ -97,7 +97,7 @@ class HilbertSeries(object):
     @property
     def nvariables(self):
         """
-        Return the no. of variables
+        Return the no. of variables.
 
         EXAMPLES::
 
@@ -112,7 +112,7 @@ class HilbertSeries(object):
     @property
     def degrees(self):
         """
-        Return a list of degrees of the polynomials
+        Return a list of degrees of the polynomials.
 
         EXAMPLES::
 
@@ -127,19 +127,17 @@ class HilbertSeries(object):
     @property
     def precision(self):
         """
-        Return the default precision of the series
+        Return the precision of the series.
 
         EXAMPLES::
 
             sage: from cryptographic_estimators.MQEstimator.series.hilbert import HilbertSeries
-            sage: H = HilbertSeries(5, [2]*7)
+            sage: H = HilbertSeries(5, [3]*7)
             sage: H.precision
             14
 
         """
-        x = self._gen
-        serie_repr = x.repr()
-        return int(serie_repr[serie_repr.rfind("=") + 1 : serie_repr.rfind(")")])
+        return self._prec
 
     @property
     def npolynomials(self):
@@ -197,7 +195,7 @@ class HilbertSeries(object):
 
     def first_nonpositive_coefficient(self):
         """
-        Return the first non-positive integer of the series
+        Return the first non-positive integer of the series.
 
         EXAMPLES::
 
@@ -215,7 +213,7 @@ class HilbertSeries(object):
 
     def first_nonpositive_coefficient_up_to_degree(self):
         """
-        Return the first non-positive integer of the serie `self._series/(1-x)`
+        Return the first non-positive integer of the serie `self._series/(1-x)`.
 
 
         EXAMPLES::

--- a/cryptographic_estimators/MQEstimator/series/hilbert.py
+++ b/cryptographic_estimators/MQEstimator/series/hilbert.py
@@ -47,6 +47,7 @@ class HilbertSeries(object):
         self._q = q
         self._nvariables = n
         self._degrees = degrees
+        # Precision sufficient for systems with variables not exceeding equations.
         self._prec = 2 * len(self._degrees)
         self._gen = power_series([0, 1], prec=self._prec)
         x = self._gen

--- a/cryptographic_estimators/MQEstimator/series/hilbert.py
+++ b/cryptographic_estimators/MQEstimator/series/hilbert.py
@@ -173,7 +173,7 @@ class HilbertSeries(object):
 
             sage: from cryptographic_estimators.MQEstimator.series.hilbert import HilbertSeries
             sage: H = HilbertSeries(10, [2]*15)
-            sage: H.first_nonpositive_integer()
+            sage: H.first_nonpositive_coefficient()
             4
 
         """
@@ -183,10 +183,29 @@ class HilbertSeries(object):
                 return int(d)
         raise ValueError("Unable to find a nonpositive coefficient in the serie.")
 
+    def first_nonpositive_coefficient_up_to_degree(self):
+        """
+        Return the first non-positive integer of the serie `self._series/(1-x)`
+
+
+        EXAMPLES::
+
+            sage: from cryptographic_estimators.MQEstimator.series.hilbert import HilbertSeries
+            sage: H = HilbertSeries(10, [2]*15)
+            sage: H.first_nonpositive_coefficient_up_to_degree()
+            5
+
+        """
+        for d in range(self.precision):
+            if self._series_up_to_degree[d] <= 0:
+                return int(d)
+        raise ValueError(
+            "Unable to find a nonpositive coefficient in the up_to_degree serie."
+        )
+
     def __repr__(self):
         """ """
         text = f"Hilbert series for system with {self.nvariables} variables and {self.npolynomials} polynomials"
         if self._q is not None:
             text += f" over F_{self._q}"
         return text
-

--- a/cryptographic_estimators/MQEstimator/witness_degree.py
+++ b/cryptographic_estimators/MQEstimator/witness_degree.py
@@ -40,15 +40,15 @@ def semi_regular_system(n: int, degrees: list[int], q=None):
     m = len(degrees)
     if m <= n and q is None:
         raise ValueError(
-            "The number of polynomials must be greater than the number of variables")
+            "The number of polynomials must be greater than the number of variables"
+        )
     elif m < n and q is not None:
         raise ValueError(
-            "The number of polynomials must be greater than or equal to the number of variables")
+            "The number of polynomials must be greater than or equal to the number of variables"
+        )
 
     serie = HilbertSeries(n, degrees, q=q)
-    x = serie._gen
-    serie._series /= (1 - x)
-    return serie.first_nonpositive_coefficient()
+    return serie.first_nonpositive_coefficient_up_to_degree()
 
 
 def quadratic_system(n: int, m: int, q=None):

--- a/cryptographic_estimators/MQEstimator/witness_degree.py
+++ b/cryptographic_estimators/MQEstimator/witness_degree.py
@@ -45,10 +45,10 @@ def semi_regular_system(n: int, degrees: list[int], q=None):
         raise ValueError(
             "The number of polynomials must be greater than or equal to the number of variables")
 
-    s = HilbertSeries(n, degrees, q=q)
-    z = s.ring.gen()
-    s._series /= (1 - z)
-    return s.first_nonpositive_integer()
+    serie = HilbertSeries(n, degrees, q=q)
+    x = serie._gen
+    serie._series /= (1 - x)
+    return serie.first_nonpositive_coefficient()
 
 
 def quadratic_system(n: int, m: int, q=None):


### PR DESCRIPTION
### Description
- Complete reimplementation of the nmonomials class to use python-flint power series instead of Sage power series.
  - Remove of the `_ring` attribute, replacing its use by the new attribute `_gen`.
  - Remove the `series` method, to be replaced by the new methods `coefficient_of_degree` and `coefficient_up_to_degree`.
  - Rename the method `first_nonpositive_integer` as `first_nonpositive_coefficient`.
- Updated all references to the Hilbert Series class to ensure compatibility with the new implementation.
- Stylistic changes via Black formatter.

### Review process
- Major changes are in the reimplementation of HilbertSeries and the used form to call the series in Crossbred.
- Any other change should be minor or stylistic.


### Pre-approval checklist
- [x] The code builds clean without any errors or warnings
- [x] I've added/updated tests
- [x] I've added/updated documentation if needed
