### PR TITLE
Refactor/new docstrings styling

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -40,5 +40,9 @@ jobs:
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
-      - name: Run tests
+      - name: Run Sage doctests
         run: make docker-test
+
+      - name: Run pytest
+        run: make docker-pytest
+

--- a/Makefile
+++ b/Makefile
@@ -71,10 +71,67 @@ docker-doc: docker-build
 	@make mount-volume-and-run && make generate-documentation && make stop-container-and-remove container_name="container-for-docs"
 
 docker-test: docker-build
-	@docker run --name container-for-test -d -it ${image_name} sh && docker exec container-for-test sage -t --long -T 3600 --force-lib cryptographic_estimators && docker stop container-for-test && docker rm container-for-test
+	@echo "Removing previous container...."
+	@make stop-container-and-remove container_name="container-for-test" \
+		|| true
+	@echo "Creating container..."
+	@docker run --name container-for-test -d -it ${image_name} sh \
+		&& docker exec container-for-test sh -c " \
+		sage -t --long --timeout 3600 --force-lib \
+		# cryptographic_estimators/SDEstimator/ \
+		cryptographic_estimators/DummyEstimator/ \
+		cryptographic_estimators/LEEstimator/ \
+		cryptographic_estimators/MAYOEstimator/ \
+		cryptographic_estimators/MQEstimator/ \
+		cryptographic_estimators/MREstimator/ \
+		cryptographic_estimators/PEEstimator/ \
+		cryptographic_estimators/PKEstimator/ \
+		cryptographic_estimators/RegSDEstimator/ \
+		cryptographic_estimators/SDFqEstimator/ \
+		cryptographic_estimators/UOVEstimator/ \
+		cryptographic_estimators/base_algorithm.py \
+		cryptographic_estimators/base_constants.py \
+		cryptographic_estimators/base_estimator.py \
+		cryptographic_estimators/base_problem.py \
+		cryptographic_estimators/estimation_renderer.py \
+		cryptographic_estimators/helper.py \
+		" \
+		&& echo "All tests passed." \
+		|| echo "Some test have failed, please see previous lines."
+	@echo "Cleaning container..."
+	@make stop-container-and-remove container_name="container-for-test"
+
 
 docker-testfast: docker-build
-	@docker run --name container-for-test -d -it ${image_name} sh && docker exec container-for-test sage -t cryptographic_estimators && make stop-container-and-remove container_name="container-for-test"
+	@echo "Removing previous container...."
+	@make stop-container-and-remove container_name="container-for-test" \
+		|| true
+	@echo "Creating container..."
+	@docker run --name container-for-test -d -it ${image_name} sh \
+		&& docker exec container-for-test sh -c " \
+		sage -t --timeout 3600 --force-lib \
+		# cryptographic_estimators/SDEstimator/ \
+		cryptographic_estimators/DummyEstimator/ \
+		cryptographic_estimators/LEEstimator/ \
+		cryptographic_estimators/MAYOEstimator/ \
+		cryptographic_estimators/MQEstimator/ \
+		cryptographic_estimators/MREstimator/ \
+		cryptographic_estimators/PEEstimator/ \
+		cryptographic_estimators/PKEstimator/ \
+		cryptographic_estimators/RegSDEstimator/ \
+		cryptographic_estimators/SDFqEstimator/ \
+		cryptographic_estimators/UOVEstimator/ \
+		cryptographic_estimators/base_algorithm.py \
+		cryptographic_estimators/base_constants.py \
+		cryptographic_estimators/base_estimator.py \
+		cryptographic_estimators/base_problem.py \
+		cryptographic_estimators/estimation_renderer.py \
+		cryptographic_estimators/helper.py \
+		" \
+		&& echo "All tests passed." \
+		|| echo "Some test have failed, please see previous lines."
+	@echo "Cleaning container..."
+	@make stop-container-and-remove container_name="container-for-test"
 
 add-copyright:
 	@python3 scripts/create_copyright.py
@@ -85,17 +142,48 @@ docker-pytest:
 		|| true
 	@echo "Creating container..."
 	@docker run --name pytest-estimators -d -it ${image_name} sh \
-		&& docker exec pytest-estimators sh -c "sage --python3 -m pytest -n auto -vv \
-		--cov-report xml:coverage.xml --cov=${PACKAGE} \
-		&& ${SAGE} tests/SDFqEstimator/test_sdfq.sage \
-		&& ${SAGE} tests/LEEstimator/test_le_beullens.sage \
-		&& ${SAGE} tests/LEEstimator/test_le_bbps.sage \
-		&& ${SAGE} tests/PEEstimator/test_pe.sage \
-		&& ${SAGE} tests/PKEstimator/test_pk.sage" \
-		&& echo "All tests passed." \
-		|| echo "Some test have failed, please see previous lines."
+		&& docker exec pytest-estimators sh -c " \
+		pytest --doctest-modules -n auto -vv \
+		cryptographic_estimators/SDEstimator/ \
+		# cryptographic_estimators/DummyEstimator/ \
+		# cryptographic_estimators/LEEstimator/ \
+		# cryptographic_estimators/MAYOEstimator/ \
+		# cryptographic_estimators/MQEstimator/ \
+		# cryptographic_estimators/MREstimator/ \
+		# cryptographic_estimators/PEEstimator/ \
+		# cryptographic_estimators/PKEstimator/ \
+		# cryptographic_estimators/RegSDEstimator/ \
+		# cryptographic_estimators/SDFqEstimator/ \
+		# cryptographic_estimators/UOVEstimator/ \
+		# cryptographic_estimators/base_algorithm.py \
+		# cryptographic_estimators/base_constants.py \
+		# cryptographic_estimators/base_estimator.py \
+		# cryptographic_estimators/base_problem.py \
+		# cryptographic_estimators/estimation_renderer.py \
+		# cryptographic_estimators/helper.py \
+		# tests/ \
+		" \
 	@echo "Cleaning container..."
 	@make stop-container-and-remove container_name="pytest-estimators"
+
+
+# docker-pytest:
+# 	@echo "Removing previous container...."
+# 	@make stop-container-and-remove container_name="pytest-estimators" \
+# 		|| true
+# 	@echo "Creating container..."
+# 	@docker run --name pytest-estimators -d -it ${image_name} sh \
+# 		&& docker exec pytest-estimators sh -c "sage --python3 -m pytest -n auto -vv \
+# 		--cov-report xml:coverage.xml --cov=${PACKAGE} \
+# 		&& ${SAGE} tests/SDFqEstimator/test_sdfq.sage \
+# 		&& ${SAGE} tests/LEEstimator/test_le_beullens.sage \
+# 		&& ${SAGE} tests/LEEstimator/test_le_bbps.sage \
+# 		&& ${SAGE} tests/PEEstimator/test_pe.sage \
+# 		&& ${SAGE} tests/PKEstimator/test_pk.sage" \
+# 		&& echo "All tests passed." \
+# 		|| echo "Some test have failed, please see previous lines."
+# 	@echo "Cleaning container..."
+# 	@make stop-container-and-remove container_name="pytest-estimators"
 
 docker-pytest-cov:
 	pytest -v --cov-report xml:coverage.xml --cov=${PACKAGE} tests/

--- a/conftest.py
+++ b/conftest.py
@@ -3,13 +3,15 @@ import pytest
 
 def pytest_addoption(parser):
     parser.addoption(
-        "--long-doctests",
+        "--skip-long-doctests",
         action="store_true",
         default=False,
-        help="run long doctests",
+        help="Flag to skip long time execution doctests",
     )
 
 
 @pytest.fixture(autouse=True)
 def add_longtests(request, doctest_namespace):
-    doctest_namespace["long_doctests"] = request.config.getoption("--long-doctests")
+    doctest_namespace["skip_long_doctests"] = request.config.getoption(
+        "--skip-long-doctests"
+    )

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,15 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--long-doctests",
+        action="store_true",
+        default=False,
+        help="run long doctests",
+    )
+
+
+@pytest.fixture(autouse=True)
+def add_longtests(request, doctest_namespace):
+    doctest_namespace["long_doctests"] = request.config.getoption("--long-doctests")

--- a/cryptographic_estimators/SDEstimator/sd_estimator.py
+++ b/cryptographic_estimators/SDEstimator/sd_estimator.py
@@ -15,23 +15,6 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 # ****************************************************************************
 
-# ****************************************************************************
-# Copyright 2023 Technology Innovation Institute
-
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
-# ****************************************************************************
-
 
 from ..SDEstimator.sd_algorithm import SDAlgorithm
 from ..SDEstimator.sd_problem import SDProblem
@@ -41,19 +24,17 @@ from math import inf
 
 
 class SDEstimator(BaseEstimator):
-    """
-    Construct an instance of Syndrome Decoding Estimator
+    """Construct an instance of Syndrome Decoding Estimator.
 
-    INPUT:
+    Args:
+        n (int): Code length.
+        k (int): Code dimension.
+        w (int): Error weight.
+        excluded_algorithms (Union[List, Tuple], optional): A list or tuple of excluded algorithms. Defaults to None.
+        nsolutions (int): Number of solutions.
 
-    - ``n`` -- code length
-    - ``k`` -- code dimension
-    - ``w`` -- error weight
-    - ``excluded_algorithms`` -- a list/tuple of excluded algorithms (default: None)
-    - ``nsolutions`` -- no. of solutions
-
-    TODO: Maybe we should add the optional_parameters dictionary here?
-
+    Todo:
+        * Maybe we should add the optional_parameters dictionary here?
     """
 
     excluded_algorithms_by_default = [BJMMd2, BJMMd3, MayOzerovD2, MayOzerovD3]
@@ -64,27 +45,33 @@ class SDEstimator(BaseEstimator):
 
         kwargs["excluded_algorithms"] += self.excluded_algorithms_by_default
 
-        super(SDEstimator, self).__init__(SDAlgorithm, SDProblem(
-            n, k, w, memory_bound=memory_bound, **kwargs), **kwargs)
+        super(SDEstimator, self).__init__(
+            SDAlgorithm,
+            SDProblem(n, k, w, memory_bound=memory_bound, **kwargs),
+            **kwargs
+        )
 
-    def table(self, show_quantum_complexity=0, show_tilde_o_time=0,
-              show_all_parameters=0, precision=1, truncate=0):
-        """
-        Print table describing the complexity of each algorithm and its optimal parameters
+    def table(
+        self,
+        show_quantum_complexity=0,
+        show_tilde_o_time=0,
+        show_all_parameters=0,
+        precision=1,
+        truncate=0,
+    ):
+        """Print table describing the complexity of each algorithm and its optimal parameters.
 
-        INPUT:
+        Args:
+            show_quantum_complexity (int, optional): Show quantum time complexity. Defaults to 0.
+            show_tilde_o_time (int, optional): Show Ō time complexity. Defaults to 0.
+            show_all_parameters (int, optional): Show all optimization parameters. Defaults to 0.
+            precision (int, optional): Number of decimal digits output. Defaults to 1.
+            truncate (int, optional): Truncate rather than round the output. Defaults to 0.
 
-        - ``show_quantum_complexity`` -- show quantum time complexity (default: true)
-        - ``show_tilde_o_time`` -- show Ō time complexity (default: true)
-        - ``show_all_parameters`` -- show all optimization parameters (default: true)
-        - ``precision`` -- number of decimal digits output (default: 1)
-        - ``truncate`` -- truncate rather than round the output (default: false)
-
-        EXAMPLES:
-
-            sage: from cryptographic_estimators.SDEstimator import SDEstimator
-            sage: A = SDEstimator(n=100, k=50, w=10)
-            sage: A.table()
+        Examples:
+            >>> from cryptographic_estimators.SDEstimator import SDEstimator
+            >>> A = SDEstimator(n=100, k=50, w=10)
+            >>> A.table()
             +---------------+---------------+
             |               |    estimate   |
             +---------------+------+--------+
@@ -102,12 +89,12 @@ class SDEstimator(BaseEstimator):
             | Stern         | 22.3 |   16.0 |
             +---------------+------+--------+
 
-        TESTS:
 
-            sage: from cryptographic_estimators.SDEstimator import SDEstimator
-            sage: from cryptographic_estimators.SDEstimator import BothMay
-            sage: A = SDEstimator(n=100, k=42, w=13, bit_complexities=1,excluded_algorithms=[BothMay], workfactor_accuracy=25)
-            sage: A.table(show_tilde_o_time=1, precision=0) # long time
+        Tests:
+            >>> from cryptographic_estimators.SDEstimator import SDEstimator
+            >>> from cryptographic_estimators.SDEstimator import BothMay
+            >>> A = SDEstimator(n=100, k=42, w=13, bit_complexities=1,excluded_algorithms=[BothMay], workfactor_accuracy=25)
+            >>> A.table(show_tilde_o_time=1, precision=0) # pytest.skip
             +---------------+---------------+------------------+
             |               |    estimate   | tilde_o_estimate |
             +---------------+------+--------+-------+----------+
@@ -124,10 +111,10 @@ class SDEstimator(BaseEstimator):
             | Stern         |   23 |     16 |    11 |        3 |
             +---------------+------+--------+-------+----------+
 
-            sage: from cryptographic_estimators.SDEstimator import SDEstimator
-            sage: from cryptographic_estimators.SDEstimator.SDAlgorithms import BJMMdw
-            sage: A = SDEstimator(3488,2720,64,excluded_algorithms=[BJMMdw])
-            sage: A.table(precision=3, show_all_parameters=1) # long time
+            >>> from cryptographic_estimators.SDEstimator import SDEstimator
+            >>> from cryptographic_estimators.SDEstimator.SDAlgorithms import BJMMdw
+            >>> A = SDEstimator(3488, 2720, 64, excluded_algorithms=[BJMMdw])
+            >>> A.table(precision=3, show_all_parameters=1) # pytest.skip
             +---------------+--------------------------------------------------------------------------------+
             |               |                                    estimate                                    |
             +---------------+---------+---------+------------------------------------------------------------+
@@ -144,10 +131,10 @@ class SDEstimator(BaseEstimator):
             | Stern         | 151.409 |  49.814 |                 {'r': 7, 'p': 4, 'l': 39}                  |
             +---------------+---------+---------+------------------------------------------------------------+
 
-            sage: from cryptographic_estimators.SDEstimator import SDEstimator
-            sage: from cryptographic_estimators.SDEstimator.SDAlgorithms import BJMMdw
-            sage: A = SDEstimator(3488,2720,64,excluded_algorithms=[BJMMdw],memory_access=3)
-            sage: A.table(precision=3, show_all_parameters=1) # long time
+            >>> from cryptographic_estimators.SDEstimator import SDEstimator
+            >>> from cryptographic_estimators.SDEstimator.SDAlgorithms import BJMMdw
+            >>> A = SDEstimator(3488,2720,64,excluded_algorithms=[BJMMdw],memory_access=3)
+            >>> A.table(precision=3, show_all_parameters=1) # pytest.skip
             +---------------+----------------------------------------------------------------------------+
             |               |                                  estimate                                  |
             +---------------+---------+--------+---------------------------------------------------------+
@@ -165,7 +152,10 @@ class SDEstimator(BaseEstimator):
             +---------------+---------+--------+---------------------------------------------------------+
 
         """
-        super(SDEstimator, self).table(show_quantum_complexity=show_quantum_complexity,
-                                       show_tilde_o_time=show_tilde_o_time,
-                                       show_all_parameters=show_all_parameters,
-                                       precision=precision, truncate=truncate)
+        super(SDEstimator, self).table(
+            show_quantum_complexity=show_quantum_complexity,
+            show_tilde_o_time=show_tilde_o_time,
+            show_all_parameters=show_all_parameters,
+            precision=precision,
+            truncate=truncate,
+        )

--- a/cryptographic_estimators/SDEstimator/sd_estimator.py
+++ b/cryptographic_estimators/SDEstimator/sd_estimator.py
@@ -91,7 +91,7 @@ class SDEstimator(BaseEstimator):
 
 
         Tests:
-            >>> if not long_doctests:
+            >>> if skip_long_doctests:
             ...     pytest.skip()
             >>> from cryptographic_estimators.SDEstimator import SDEstimator
             >>> from cryptographic_estimators.SDEstimator import BothMay

--- a/cryptographic_estimators/SDEstimator/sd_estimator.py
+++ b/cryptographic_estimators/SDEstimator/sd_estimator.py
@@ -15,12 +15,12 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 # ****************************************************************************
 
-
+import pytest
+from math import inf
 from ..SDEstimator.sd_algorithm import SDAlgorithm
 from ..SDEstimator.sd_problem import SDProblem
 from ..SDEstimator.SDAlgorithms import BJMMd2, BJMMd3, MayOzerovD2, MayOzerovD3
 from ..base_estimator import BaseEstimator
-from math import inf
 
 
 class SDEstimator(BaseEstimator):
@@ -91,10 +91,12 @@ class SDEstimator(BaseEstimator):
 
 
         Tests:
+            >>> if not long_doctests:
+            ...     pytest.skip()
             >>> from cryptographic_estimators.SDEstimator import SDEstimator
             >>> from cryptographic_estimators.SDEstimator import BothMay
             >>> A = SDEstimator(n=100, k=42, w=13, bit_complexities=1,excluded_algorithms=[BothMay], workfactor_accuracy=25)
-            >>> A.table(show_tilde_o_time=1, precision=0) # pytest.skip
+            >>> A.table(show_tilde_o_time=1, precision=0)
             +---------------+---------------+------------------+
             |               |    estimate   | tilde_o_estimate |
             +---------------+------+--------+-------+----------+
@@ -114,7 +116,7 @@ class SDEstimator(BaseEstimator):
             >>> from cryptographic_estimators.SDEstimator import SDEstimator
             >>> from cryptographic_estimators.SDEstimator.SDAlgorithms import BJMMdw
             >>> A = SDEstimator(3488, 2720, 64, excluded_algorithms=[BJMMdw])
-            >>> A.table(precision=3, show_all_parameters=1) # pytest.skip
+            >>> A.table(precision=3, show_all_parameters=1)
             +---------------+--------------------------------------------------------------------------------+
             |               |                                    estimate                                    |
             +---------------+---------+---------+------------------------------------------------------------+
@@ -134,7 +136,7 @@ class SDEstimator(BaseEstimator):
             >>> from cryptographic_estimators.SDEstimator import SDEstimator
             >>> from cryptographic_estimators.SDEstimator.SDAlgorithms import BJMMdw
             >>> A = SDEstimator(3488,2720,64,excluded_algorithms=[BJMMdw],memory_access=3)
-            >>> A.table(precision=3, show_all_parameters=1) # pytest.skip
+            >>> A.table(precision=3, show_all_parameters=1)
             +---------------+----------------------------------------------------------------------------+
             |               |                                  estimate                                  |
             +---------------+---------+--------+---------------------------------------------------------+
@@ -150,7 +152,6 @@ class SDEstimator(BaseEstimator):
             | Prange        | 173.447 | 21.576 |                         {'r': 7}                        |
             | Stern         | 153.015 | 32.587 |                {'r': 7, 'p': 2, 'l': 21}                |
             +---------------+---------+--------+---------------------------------------------------------+
-
         """
         super(SDEstimator, self).table(
             show_quantum_complexity=show_quantum_complexity,


### PR DESCRIPTION
### Description

After three weeks researching about alternatives to run doctests dinamically, I finally found how to put the pieces together. The result is this PR where we have:

- The implementation of the first doctests migration from Sagemath to Python.
- The changes proposed here https://github.com/Crypto-TII/CryptographicEstimators/issues/162, to change the docstrings style into a more standard approach (Google docstrings).
- The creation of a pytest CLI option, so we can trigger the dynamic definition of a boolean flag via pytest fixtures.
-  A new docstrings logic to dinamically decide if we run or not long doctests.

I made the changes in just one file so we can discuss any aspect, before go all-in.

#### How this changes work

At `conftest.py`
1. We now have a [pytest fixture](https://docs.pytest.org/en/6.2.x/fixture.html) called automatically on each `pytest` CLI execution, as well as a new pytest CLI option called `--long-doctests`,  that defaults to False but changes to True when provided.
2. Whatever value we get from this CLI option, we put it into a `long_doctests` variable that is later passed to the *"context"* of our doctests via [`doctest_namespaces` fixtures
](https://docs.pytest.org/en/7.1.x/how-to/doctest.html#doctest-namespace-fixture)

At `sd_estimator.py`

We now have to collect all the tests that could take a long time to run, and put them at the end of the `Tests:` section. This way, we can use the `long_doctests` flag comming from the pytest context, and with the conditional
```python 
>>> if not long_doctests:
 ...     pytest.skip()
```
Ensure that every test block after that will be run only if the flag `long_doctests` is True (i.e., if we made the `pytest` call with the `--long-doctests` option).

#### Pros and drawbacks

**Pros**
1. The `#long time` functionality of Sage markers is, essentially, preserved.

**Drawbacks**
1. Now we don't have the granularity of a docstring marker, so we can't alternate between long and short time blocks inside a docstring. Every long test should be at the end of the `Tests` section.
2. When the `--long-doctests` option is not provided to the `pytest` call, all the tests containing long test are reported as **skipped** instead of **passed**. While this shouldn't have any technical implication, because short failing tests still produces a pytest error, I think it's worth to mention it.

### Review process
- For short tests/examples:
    - Run `pytest --doctest-modules cryptographic_estimators/SDEstimator/sd_estimator.py` in the shell. It will work, and the pytest return will be `1 skipped`.
    - Change some value of the expected output for the `Examples:` section of the docstring, and save the file. Run the same command again and, as expected, pytest will return `1 failed`.
- For long tests:
  - Run `pytest --long-doctests --doctest-modules cryptographic_estimators/SDEstimator/sd_estimator.py`. Long tests defined after the previousd conditional, will be executed and the pytest call will return `1 passed`.

### Pre-approval checklist
- [x] The code builds clean without any errors or warnings
- [x] I've added/updated tests
- [x] I've added/updated documentation if needed
