### PR TITLE
Fix/value error uov mayo

### DIFF
--- a/cryptographic_estimators/MAYOEstimator/MAYOAlgorithms/claw_finding.py
+++ b/cryptographic_estimators/MAYOEstimator/MAYOAlgorithms/claw_finding.py
@@ -37,7 +37,6 @@ class ClawFinding(MAYOAlgorithm):
     - ``problem`` -- MAYOProblem object including all necessary parameters
     - ``w`` -- linear algebra constant (default: obtained from MAYOAlgorithm)
     - ``h`` -- external hybridization parameter (default: 0)
-    - ``nsolutions`` -- number of solutions in logarithmic scale (default: expected_number_solutions))
     - ``excluded_algorithms`` -- a list/tuple of MQ algorithms to be excluded (default: [Lokshtanov])
     - ``memory_access`` -- specifies the memory access cost model (default: 0, choices: 0 - constant, 1 - logarithmic, 2 - square-root, 3 - cube-root or deploy custom function which takes as input the logarithm of the total memory usage)
     - ``complexity_type`` -- complexity type to consider (0: estimate, default: 0)

--- a/cryptographic_estimators/MAYOEstimator/MAYOAlgorithms/direct_attack.py
+++ b/cryptographic_estimators/MAYOEstimator/MAYOAlgorithms/direct_attack.py
@@ -58,7 +58,6 @@ class DirectAttack(MAYOAlgorithm):
         n_tilde = m_tilde - K
         w = self.linear_algebra_constant()
         h = self._h
-        nsolutions = self.problem.expected_number_solutions()
         excluded_algorithms = kwargs.get(BASE_EXCLUDED_ALGORITHMS, [Lokshtanov])
         complexity_type = self.complexity_type
 
@@ -70,7 +69,6 @@ class DirectAttack(MAYOAlgorithm):
         self._MQEstimator = MQEstimator(n=n_tilde, m=m_tilde, q=q,
                                         w=w,
                                         h=h,
-                                        nsolutions=nsolutions,
                                         excluded_algorithms=excluded_algorithms,
                                         memory_access=0,
                                         complexity_type=complexity_type,

--- a/cryptographic_estimators/MAYOEstimator/MAYOAlgorithms/direct_attack.py
+++ b/cryptographic_estimators/MAYOEstimator/MAYOAlgorithms/direct_attack.py
@@ -38,7 +38,6 @@ class DirectAttack(MAYOAlgorithm):
     - ``problem`` -- MAYOProblem object including all necessary parameters
     - ``w`` -- linear algebra constant (default: obtained from MAYOAlgorithm)
     - ``h`` -- external hybridization parameter (default: 0)
-    - ``nsolutions`` -- number of solutions in logarithmic scale (default: expected_number_solutions))
     - ``excluded_algorithms`` -- a list/tuple of MQ algorithms to be excluded (default: [Lokshtanov])
     - ``memory_access`` -- specifies the memory access cost model (default: 0, choices: 0 - constant, 1 - logarithmic, 2 - square-root, 3 - cube-root or deploy custom function which takes as input the logarithm of the total memory usage)
     - ``complexity_type`` -- complexity type to consider (0: estimate, default: 0)

--- a/cryptographic_estimators/MAYOEstimator/MAYOAlgorithms/intersection_attack.py
+++ b/cryptographic_estimators/MAYOEstimator/MAYOAlgorithms/intersection_attack.py
@@ -36,7 +36,6 @@ class IntersectionAttack(MAYOAlgorithm):
     - ``problem`` -- MAYOProblem object including all necessary parameters
     - ``w`` -- linear algebra constant (default: Obtained from MAYOAlgorithm)
     - ``h`` -- external hybridization parameter (default: 0)
-    - ``nsolutions`` -- number of solutions in logarithmic scale (default: expected_number_solutions))
     - ``excluded_algorithms`` -- a list/tuple of MQ algorithms to be excluded (default: [Lokshtanov])
     - ``memory_access`` -- specifies the memory access cost model (default: 0, choices: 0 - constant, 1 - logarithmic, 2 - square-root, 3 - cube-root or deploy custom function which takes as input the logarithm of the total memory usage)
     - ``complexity_type`` -- complexity type to consider (0: estimate, default: 0)

--- a/cryptographic_estimators/MAYOEstimator/MAYOAlgorithms/kipnis_shamir.py
+++ b/cryptographic_estimators/MAYOEstimator/MAYOAlgorithms/kipnis_shamir.py
@@ -39,7 +39,6 @@ class KipnisShamir(MAYOAlgorithm):
     - ``problem`` -- MAYOProblem object including all necessary parameters
     - ``w_ks`` -- linear algebra constant (only for kipnis-shamir algorithm) (default: 2.8)
     - ``h`` -- external hybridization parameter (default: 0)
-    - ``nsolutions`` -- number of solutions in logarithmic scale (default: expected_number_solutions))
     - ``excluded_algorithms`` -- a list/tuple of MQ algorithms to be excluded (default: [Lokshtanov])
     - ``memory_access`` -- specifies the memory access cost model (default: 0, choices: 0 - constant, 1 - logarithmic, 2 - square-root, 3 - cube-root or deploy custom function which takes as input the logarithm of the total memory usage)
     - ``complexity_type`` -- complexity type to consider (0: estimate, default: 0)

--- a/cryptographic_estimators/MAYOEstimator/MAYOAlgorithms/reconciliation_attack.py
+++ b/cryptographic_estimators/MAYOEstimator/MAYOAlgorithms/reconciliation_attack.py
@@ -35,7 +35,6 @@ class ReconciliationAttack(MAYOAlgorithm):
     - ``problem`` -- MAYOProblem object including all necessary parameters
     - ``w`` -- linear algebra constant (default: obtained from MAYOAlgorithm)
     - ``h`` -- external hybridization parameter (default: 0)
-    - ``nsolutions`` -- number of solutions in logarithmic scale (default: expected_number_solutions))
     - ``excluded_algorithms`` -- a list/tuple of MQ algorithms to be excluded (default: [Lokshtanov])
     - ``memory_access`` -- specifies the memory access cost model (default: 0, choices: 0 - constant, 1 - logarithmic, 2 - square-root, 3 - cube-root or deploy custom function which takes as input the logarithm of the total memory usage)
     - ``complexity_type`` -- complexity type to consider (0: estimate, default: 0)

--- a/cryptographic_estimators/MAYOEstimator/mayo_estimator.py
+++ b/cryptographic_estimators/MAYOEstimator/mayo_estimator.py
@@ -130,17 +130,17 @@ class MAYOEstimator(BaseEstimator):
 
             sage: E = MAYOEstimator(n=90, m=56, o=8, k=10, q=16) # long test
             sage: E.table(show_all_parameters=1) # long time
-            +----------------------+--------------+-----------------------------------------------------------+
-            |                      |              |                          estimate                         |
-            +----------------------+--------------+-------+--------+------------------------------------------+
-            | algorithm            | attack_type  |  time | memory |                parameters                |
-            +----------------------+--------------+-------+--------+------------------------------------------+
-            | DirectAttack         |   forgery    |  21.4 |   20.8 | {'K': 10, 'variant': 'ExhaustiveSearch'} |
-            | KipnisShamir         | key-recovery | 319.3 |   18.0 |                    {}                    |
-            | ReconciliationAttack | key-recovery | 150.3 |   43.8 |    {'k': 13, 'variant': 'las_vegas'}     |
-            | IntersectionAttack   | key-recovery | 399.1 |   59.1 |     {'k': 0, 'variant': 'las_vegas'}     |
-            | ClawFinding          |   forgery    | 126.0 |  116.0 |       {'X': 115.011, 'Y': 108.989}       |
-            +----------------------+--------------+-------+--------+------------------------------------------+
+            +----------------------+--------------+------------------------------------------------------------------+
+            |                      |              |                             estimate                             |
+            +----------------------+--------------+-------+--------+-------------------------------------------------+
+            | algorithm            | attack_type  |  time | memory |                    parameters                   |
+            +----------------------+--------------+-------+--------+-------------------------------------------------+
+            | DirectAttack         |   forgery    | 109.3 |   29.9 | {'k': 0, 'variant': 'BooleanSolveFXL', 'K': 10} |
+            | KipnisShamir         | key-recovery | 319.3 |   18.0 |                        {}                       |
+            | ReconciliationAttack | key-recovery | 150.3 |   43.8 |        {'k': 13, 'variant': 'las_vegas'}        |
+            | IntersectionAttack   | key-recovery | 399.1 |   59.1 |         {'k': 0, 'variant': 'las_vegas'}        |
+            | ClawFinding          |   forgery    | 126.0 |  116.0 |           {'X': 115.011, 'Y': 108.989}          |
+            +----------------------+--------------+-------+--------+-------------------------------------------------+
 
             sage: E = MAYOEstimator(n=64, m=60, o=10, k=21, q=16) # long time
             sage: E.table(show_all_parameters=1) # long time

--- a/cryptographic_estimators/MAYOEstimator/mayo_problem.py
+++ b/cryptographic_estimators/MAYOEstimator/mayo_problem.py
@@ -37,7 +37,6 @@ class MAYOProblem(BaseProblem):
     - ``theta`` -- exponent of the conversion factor (default: None)
         - If ``0 <= theta <= 2``, every multiplication in GF(q) is counted as `log2(q) ^ theta` binary operation.
         - If ``theta = None``, every multiplication in GF(q) is counted as `2 * log2(q) ^ 2 + log2(q)` binary operation.
-    - ``nsolutions`` --  number of solutions in logarithmic scale (default: log2(q) * (n - m))
     - ``cost_one_hash`` -- bit complexity of computing one hash value (default: 17)
     - ``memory_bound`` -- maximum allowed memory to use for solving the problem (default: inf)
 
@@ -80,14 +79,6 @@ class MAYOProblem(BaseProblem):
         self.parameters[MAYO_FIELD_SIZE] = q
         self._theta = theta
         self._cost_one_hash = cost_one_hash
-        self.nsolutions = kwargs.get("nsolutions", self.expected_number_solutions())
-
-    def expected_number_solutions(self):
-        """
-        Returns the logarithm of the expected number of existing solutions to the problem
-        """
-        n, m, _, _, q = self.get_parameters()
-        return log2(q) * (n - m)
 
     def hashes_to_basic_operations(self, number_of_hashes: float):
         """

--- a/cryptographic_estimators/MQEstimator/MQAlgorithms/exhaustive_search.py
+++ b/cryptographic_estimators/MQEstimator/MQAlgorithms/exhaustive_search.py
@@ -18,7 +18,7 @@
 
 from ...MQEstimator.mq_algorithm import MQAlgorithm
 from ...MQEstimator.mq_problem import MQProblem
-from math import log2, log
+from math import log2, log, inf
 from sage.all import Integer
 
 
@@ -79,6 +79,7 @@ class ExhaustiveSearch(MQAlgorithm):
         time -= log2(nsolutions + 1)
         h = self._h
         time += h * log2(q)
+        if time < 0: return inf
         return time
 
     def _compute_memory_complexity(self, parameters: dict):

--- a/cryptographic_estimators/MQEstimator/MQAlgorithms/exhaustive_search.py
+++ b/cryptographic_estimators/MQEstimator/MQAlgorithms/exhaustive_search.py
@@ -79,7 +79,6 @@ class ExhaustiveSearch(MQAlgorithm):
         time -= log2(nsolutions + 1)
         h = self._h
         time += h * log2(q)
-        if time < 0: raise ValueError("time must be >= 0")
         return time
 
     def _compute_memory_complexity(self, parameters: dict):

--- a/cryptographic_estimators/MQEstimator/MQAlgorithms/exhaustive_search.py
+++ b/cryptographic_estimators/MQEstimator/MQAlgorithms/exhaustive_search.py
@@ -79,7 +79,7 @@ class ExhaustiveSearch(MQAlgorithm):
         time -= log2(nsolutions + 1)
         h = self._h
         time += h * log2(q)
-        if time < 0: return inf
+        if time < 0: raise ValueError("time must be >= 0")
         return time
 
     def _compute_memory_complexity(self, parameters: dict):

--- a/cryptographic_estimators/MQEstimator/MQAlgorithms/exhaustive_search.py
+++ b/cryptographic_estimators/MQEstimator/MQAlgorithms/exhaustive_search.py
@@ -18,7 +18,7 @@
 
 from ...MQEstimator.mq_algorithm import MQAlgorithm
 from ...MQEstimator.mq_problem import MQProblem
-from math import log2, log, inf
+from math import log2, log
 from sage.all import Integer
 
 

--- a/cryptographic_estimators/UOVEstimator/UOVAlgorithms/direct_attack.py
+++ b/cryptographic_estimators/UOVEstimator/UOVAlgorithms/direct_attack.py
@@ -20,7 +20,7 @@ from ..uov_algorithm import UOVAlgorithm
 from ..uov_problem import UOVProblem
 from ...MQEstimator.mq_estimator import MQEstimator
 from ...MQEstimator.MQAlgorithms.lokshtanov import Lokshtanov
-from ...base_constants import BASE_MEMORY_BOUND, BASE_NSOLUTIONS, BASE_BIT_COMPLEXITIES, BASE_EXCLUDED_ALGORITHMS
+from ...base_constants import BASE_MEMORY_BOUND, BASE_BIT_COMPLEXITIES, BASE_EXCLUDED_ALGORITHMS
 from math import log2
 from cryptographic_estimators.base_constants import BASE_FORGERY_ATTACK
 
@@ -37,7 +37,6 @@ class DirectAttack(UOVAlgorithm):
     - ``problem`` -- an instance of the UOVProblem class
     - ``w`` -- linear algebra constant (default: 2)
     - ``h`` -- external hybridization parameter (default: 0)
-    - ``nsolutions`` -- number of solutions in logarithmic scale (default: expected_number_solutions))
     - ``excluded_algorithms`` -- a list/tuple of MQ algorithms to be excluded (default: [Lokshtanov])
     - ``memory_access`` -- specifies the memory access cost model (default: 0, choices: 0 - constant, 1 - logarithmic, 2 - square-root, 3 - cube-root or deploy custom function which takes as input the logarithm of the total memory usage)
     - ``complexity_type`` -- complexity type to consider (0: estimate, 1: tilde O complexity, default: 0)
@@ -53,13 +52,11 @@ class DirectAttack(UOVAlgorithm):
 
         w = self.linear_algebra_constant()
         h = self._h
-        nsolutions = self.expected_number_solutions()
         excluded_algorithms = kwargs.get(BASE_EXCLUDED_ALGORITHMS, [Lokshtanov])
         complexity_type = self.complexity_type
         self._MQEstimator = MQEstimator(n=n, m=m, q=q,
                                         w=w,
                                         h=h,
-                                        nsolutions=nsolutions,
                                         excluded_algorithms=excluded_algorithms,
                                         memory_access=0,
                                         complexity_type=complexity_type,
@@ -71,13 +68,6 @@ class DirectAttack(UOVAlgorithm):
         if self._fastest_algorithm is None:
             self._fastest_algorithm = self._MQEstimator.fastest_algorithm()
         return self._fastest_algorithm
-
-    def expected_number_solutions(self):
-        """
-        Returns the logarithm of the expected number of existing solutions to the problem
-        """
-        n, m, q = self.problem.get_parameters()
-        return log2(q) * (n - m)
 
     def _compute_time_complexity(self, parameters: dict):
         """

--- a/cryptographic_estimators/UOVEstimator/UOVAlgorithms/intersection_attack.py
+++ b/cryptographic_estimators/UOVEstimator/UOVAlgorithms/intersection_attack.py
@@ -90,7 +90,7 @@ class IntersectionAttack(UOVAlgorithm):
         k = parameters["k"]
         N = k * n - (2 * k - 1) * m
         temp = (k - 1) * n - (2 * k - 1) * m
-        if N < 0 or not  temp <= 0: # Second condition is to guarantee that the attack works
+        if N <= 0 or not  temp <= 0: # Second condition is to guarantee that the attack works
             return inf
         M = binomial(k + 1, 2) * m - 2 * binomial(k, 2)
         E = BooleanSolveFXL(MQProblem(n=N, m=M, q=q), bit_complexities=0)
@@ -120,7 +120,7 @@ class IntersectionAttack(UOVAlgorithm):
         k = parameters["k"]
         N = k * n - (2 * k - 1) * m
         temp = (k - 1) * n - (2 * k - 1) * m
-        if N < 0 or not temp <= 0:
+        if N <= 0 or not temp <= 0:
             return inf
         M = binomial(k + 1, 2) * m - 2 * binomial(k, 2)
         E = BooleanSolveFXL(MQProblem(n=N, m=M, q=q), bit_complexities=0)


### PR DESCRIPTION
### Description
- Minor fix to avoid a value error when `n = 1.5 * m` in UOV `intersection_attack`
- Check if `time < 0` in `exhaustive_search` to prevent negative values in MAYO `direct_attack`
Specific example: `n=45, m=30, q=16, k=9, 0=8`



### Review process
- Check the implementation of the fixes  

### Pre-approval checklist
- [ ] The code builds clean without any errors or warnings
- [ ] I've added/updated tests
- [ ] I've added/updated documentation if needed
