### PR TITLE
Fix/apply kat test evaluation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ docker-pytest:
 	@make stop-container-and-remove container_name="pytest-estimators"
 
 
-docker-generate-kat:
+docker-generate-kat: docker-build
 	@docker run --name gen-tests-references -v ./tests:/home/cryptographic_estimators/tests --rm ${image_name} sh -c \
 		"sage tests/external_estimators/generate_kat.py"
 	@make docker-build

--- a/tests/test_kat.py
+++ b/tests/test_kat.py
@@ -90,4 +90,4 @@ def test_all_estimators(kat: dict):
         inputs, expected_outputs = zip(*inputs_with_outputs)
         internal_estimator_function = import_internal_estimator(internal_estimator_path)
         actual_outputs, epsilon = zip(*map(internal_estimator_function, inputs))
-        assert starmap(kat_test, list(zip(expected_outputs, actual_outputs, epsilon)))
+        list(starmap(kat_test, list(zip(expected_outputs, actual_outputs, epsilon))))


### PR DESCRIPTION
### Description
The `test_kat.py` file has an error where it was producing a generator to yield, one by one, the value resulting from applying the `kat_test` function to each `(expected_output, current_output, epsilon)` tuple. As consequence of this, the results haven't been calculated. This means that for any value, the tests were passing.

Additional information:

1. Because sdfq was the only other estimator with KAT tests already implemented and merged, and those results were tested with the framework discussed in #161, they are working well and haven't been affected by this error.
2. This change is proposed as a separate PR to apply it to all the future KAT migrations. It's already applied in #177 

Additional change:
- I added a really small (and non-related) commit to include `docker-build` as a dependency for the `make docker-generate-kat` command. Because of its small size, I don't think it's worth creating a separate PR for it.

### Review process
The change can be understood with this example:

```python
>>> map(lambda x:x,range(3))
<map object at 0x7f4bda478c10>
>>> list(map(lambda x:x,range(3)))
[0, 1, 2]
```
Previously we were "asserting" that the `map` object (a generator) were being created.
Now we are not asserting anything from the `test_all_estimators` function, but:
1. Letting the asserts happen on each tuple when `kat_test` is applied (as it should be).
2. Forcing `kat_test` to be applied on each tuple by using the `list()` function on the `map` object.

### Pre-approval checklist
- [x] The code builds clean without any errors or warnings
- [x] I've added/updated tests
- [x] I've added/updated documentation if needed
