### PR TITLE
refactor: remove sage from mr estimator

### DIFF
--- a/cryptographic_estimators/MREstimator/MRAlgorithms/minors.py
+++ b/cryptographic_estimators/MREstimator/MRAlgorithms/minors.py
@@ -20,7 +20,7 @@ from ...MREstimator.mr_problem import MRProblem
 from ...base_algorithm import optimal_parameter
 from math import log2, ceil
 from math import comb as binomial
-from ..mr_helper import minors_polynomial
+from ..mr_helper import minors_polynomial_degree
 from ..mr_constants import MR_NUMBER_OF_KERNEL_VECTORS_TO_GUESS, MR_NUMBER_OF_COEFFICIENTS_TO_GUESS
 
 
@@ -90,8 +90,7 @@ class Minors(MRAlgorithm):
 
     def _ME_time_memory_complexity_helper_(self, m: int, n_reduced: int, k_reduced: int, r: int, time_mem: str):
         out = 0
-        poly = minors_polynomial(m, n_reduced, k_reduced, r)
-        D = poly.degree()
+        D = minors_polynomial_degree(m, n_reduced, k_reduced, r)
         if k_reduced > 0:
             if time_mem == "time":
                 w = self._w

--- a/cryptographic_estimators/MREstimator/MRAlgorithms/support_minors.py
+++ b/cryptographic_estimators/MREstimator/MRAlgorithms/support_minors.py
@@ -15,16 +15,16 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 # ****************************************************************************
 
-from ...MREstimator.mr_algorithm import MRAlgorithm
-from ...MREstimator.mr_problem import MRProblem
-from ...base_algorithm import optimal_parameter
 from math import log2, ceil
-from sage.arith.misc import binomial
 from ..mr_constants import MR_NUMBER_OF_KERNEL_VECTORS_TO_GUESS, \
     MR_NUMBER_OF_COEFFICIENTS_TO_GUESS, \
     MR_REDUCED_NUMBER_OF_COLUMNS, \
     MR_LINEAR_VARIABLES_DEGREE, MR_VARIANT
+from ...MREstimator.mr_algorithm import MRAlgorithm
+from ...MREstimator.mr_problem import MRProblem
 from ...MREstimator.mr_helper import Variant, _strassen_complexity_, _bw_complexity_
+from ...MREstimator.mr_helper import extended_binomial as binomial
+from ...base_algorithm import optimal_parameter
 
 
 class SupportMinors(MRAlgorithm):

--- a/cryptographic_estimators/MREstimator/mr_helper.py
+++ b/cryptographic_estimators/MREstimator/mr_helper.py
@@ -17,11 +17,11 @@
 
 from math import log2
 from enum import Enum
-from sage.all import QQ
-from sage.rings.power_series_ring import PowerSeriesRing
 from itertools import product
 from math import comb as binomial
-from sage.matrix.special import zero_matrix
+from sympy import Poly, QQ
+from sympy.abc import t
+from sympy.polys.matrices import DomainMatrix
 
 
 class Variant(Enum):
@@ -57,32 +57,35 @@ def entry_i_j_of_A(n, m, t, i, j):
     limit = max(m - i, n - j)
     return sum([_binomial_mult(n, m, i, j, l) * t ** l for l in range(limit +  1)])
 
-def matrix_A(m, n, r, PR):
-    A = zero_matrix(PR, r, r)
-    t = PR.gen()
+def matrix_A(m, n, r, t):
+    A = DomainMatrix.zeros((r,r), QQ[t])
     square_r = range(1, r + 1)
     for i, j in product(square_r, square_r):
         entry_i_j = entry_i_j_of_A(n, m, t, i, j)
-        A.add_to_entry(i-1, j-1, entry_i_j)
+        A[i-1,j-1] = QQ[t].from_sympy(entry_i_j)
     return A
 
-def deteterminant_of_A(m, n, r, t):
+def determinant_of_A(m, n, r, t):
     A = matrix_A(m, n, r, t)
-    return A.determinant()
+    return A.det()
 
 def minors_series(m, n, k, r):
-    PR =  PowerSeriesRing(QQ, 't', default_prec=max(n, m) + 2)
-    t = PR.gen()
     exp = (m - r) * (n - r) - (k + 1)
-    series = (1 - t) ** exp  * deteterminant_of_A(m, n, r, PR)/(t ** binomial(r, 2))
+    num = QQ[t].from_sympy((1 - t) ** exp)  * determinant_of_A(m, n, r, t)
+    den = QQ[t].from_sympy((t ** binomial(r, 2)))
+    series = num/den
     return series
 
-def minors_polynomial(m, n_reduced, k_reduced, r):
+
+def minors_polynomial_degree(m, n_reduced, k_reduced, r):
     poly = 0
     series = minors_series(m, n_reduced, k_reduced, r)
-    t = series.parent().gen()
+    series_coeffs = list(reversed(Poly(QQ[t].to_sympy(series)).all_coeffs())) # cast from PolyElement to Poly
     for D in range(series.degree()):
-        poly += series[D] * t ** D
-        if series[D + 1] <= 0:
+        poly += series_coeffs[D] * QQ[t].from_sympy(t) ** D
+        if series_coeffs[D + 1] <= 0:
             break
-    return poly
+    return poly.degree()
+
+def extended_binomial(n, k):
+    return binomial(n,k) if n>=0 else (-1)**k * binomial(k-n-1,k)

--- a/cryptographic_estimators/MREstimator/mr_problem.py
+++ b/cryptographic_estimators/MREstimator/mr_problem.py
@@ -19,9 +19,8 @@
 from ..base_problem import BaseProblem
 from .mr_constants import *
 from ..MQEstimator.mq_helper import ngates
-from sage.arith.misc import is_prime_power
-from sage.functions.other import ceil
-from math import log2
+from cryptographic_estimators.helper import is_prime_power
+from math import log2, ceil
 
 
 class MRProblem(BaseProblem):


### PR DESCRIPTION
### Description

- Replace the usage of Sage power series for MinRank-minor-series related operations by using Sympy polynomials and matrices.

- Migration of any other Sage function into the Python native ones.

- I created an `extended_binomial(n,k)` function required for this estimator, able to handle negative `n`s.

**About performance:**

This implemention of `minors_polynomials[_degree]` is about 8x times slower than the Sage-based one. With that said, we will be able to replace Sympy with python-flint in the future by using a [C-Flint type](https://flintlib.org/doc/fmpz_poly_mat.html) used to calculate determinants over matrices of polynomials, when ported and exposed by python-flint. This should resolve (and probably even improve) the performance with respect to Sage.

### Review process

```
make docker-run
pytest --doctest-modules -n auto -vv -s cryptographic_estimators/MREstimator/
```

### Pre-approval checklist
- [x] The code builds clean without any errors or warnings
- [x] I've added/updated tests
- [x] I've added/updated documentation if needed
