### PR TITLE
Fix/html docs from kwargs

### DIFF
--- a/cryptographic_estimators/MQEstimator/MQAlgorithms/bjorklund.py
+++ b/cryptographic_estimators/MQEstimator/MQAlgorithms/bjorklund.py
@@ -59,7 +59,7 @@ class Bjorklund(MQAlgorithm):
 
     @optimal_parameter
     def lambda_(self):
-        """Return the optimal lambda_.
+        """Return the optimal lambda\_.
 
         Examples:
             >>> from cryptographic_estimators.MQEstimator.MQAlgorithms.bjorklund import Bjorklund

--- a/cryptographic_estimators/MQEstimator/MQAlgorithms/booleansolve_fxl.py
+++ b/cryptographic_estimators/MQEstimator/MQAlgorithms/booleansolve_fxl.py
@@ -51,7 +51,7 @@ class BooleanSolveFXL(MQAlgorithm):
                 1 - tilde O complexity
 
         Note:
-            For the memory complexity of 'las_vegas' variant, which is XL with the block Wiedemann algorithm, this module follows the analysis in [BBC+22]_ (Section 8). There it is stated that any row of the Macaulay matrix can be built on the fly. Hence the memory demand of this algorithm is dominated by the memory needed to store two vectors of length N over GF(q), where N is the number of columns of the Macaulay Matrix.
+            For the memory complexity of 'las_vegas' variant, which is XL with the block Wiedemann algorithm, this module follows the analysis in [BBCPSTV22]_ (Section 8). There it is stated that any row of the Macaulay matrix can be built on the fly. Hence the memory demand of this algorithm is dominated by the memory needed to store two vectors of length N over GF(q), where N is the number of columns of the Macaulay Matrix.
 
         Examples:
             >>> from cryptographic_estimators.MQEstimator.MQAlgorithms.booleansolve_fxl import BooleanSolveFXL

--- a/cryptographic_estimators/MQEstimator/MQAlgorithms/dinur1.py
+++ b/cryptographic_estimators/MQEstimator/MQAlgorithms/dinur1.py
@@ -56,7 +56,7 @@ class DinurFirst(MQAlgorithm):
 
     @optimal_parameter
     def lambda_(self):
-        """Return the optimal lambda_.
+        """Return the optimal lambda\_.
 
         Examples:
             >>> from cryptographic_estimators.MQEstimator.MQAlgorithms.dinur1 import DinurFirst

--- a/cryptographic_estimators/SDEstimator/sd_estimator.py
+++ b/cryptographic_estimators/SDEstimator/sd_estimator.py
@@ -33,8 +33,6 @@ class SDEstimator(BaseEstimator):
         excluded_algorithms (Union[List, Tuple], optional): A list or tuple of excluded algorithms. Defaults to None.
         nsolutions (int): Number of solutions.
 
-    Todo:
-        * Maybe we should add the optional_parameters dictionary here?
     """
 
     excluded_algorithms_by_default = [BJMMd2, BJMMd3, MayOzerovD2, MayOzerovD3]

--- a/docs/kwargs_formatter.py
+++ b/docs/kwargs_formatter.py
@@ -4,42 +4,40 @@ def setup(app):
     return {'version': '0.1', 'parallel_read_safe': True}
 
 def process_docstring(app, what, name, obj, options, lines):
-    formatted_lines = format_kwargs(lines)
-    lines[:] = formatted_lines
+    kwargs_start = 0
+    kwargs_end = 0
+    searching_for_kwargs = False
+    # Extract the first and last line index of the kwargs indented block
+    for i, line in enumerate(lines):
+        if ':param \\*\\*kwargs:' in line and lines[i+1]:
+            kwargs_start = i+1
+            searching_for_kwargs = True
+            continue
+        if searching_for_kwargs and not line_has_indentation(line):
+            kwargs_end = i
+            searching_for_kwargs = False
+    # If any kwargs block was found, apply the desired format
+    if kwargs_start < kwargs_end:
+        lines[kwargs_start:kwargs_end] = format_kwargs(lines[kwargs_start:kwargs_end])
 
 def format_kwargs(lines):
-    formatted_lines = []
-    in_kwargs = False
-    kwargs_items = []
-
+    kwarg_param_indent = " "*4
+    formatted_lines = ['']
+    base_indentation = len(lines[0]) - len(lines[0].lstrip())
     for line in lines:
-        if ':param \\*\\*kwargs:' in line:
-            in_kwargs = True
-            formatted_lines.append(line)
-        elif in_kwargs and line.strip():
-            kwargs_items.append(line.strip())
-        else:
-            if in_kwargs and kwargs_items:
-                formatted_lines.append('')  # Add a blank line
-                for item in kwargs_items:
-                    if ":" in item:
-                        key, value = item.split(':', 1)
-                        formatted_lines.append(f'    *{key.strip()}* - {value.strip()}')
-                        formatted_lines.append('')
-                    else:
-                        formatted_lines[-2] = formatted_lines[-2] + f' {item}'
-                formatted_lines.append('')
-                kwargs_items = []
-            in_kwargs = False
-            formatted_lines.append(line)
-
-    # Handle case where kwargs are at the end of the docstring
-    if in_kwargs and kwargs_items:
-        formatted_lines.append('')
-        for item in kwargs_items:
-            key, value = item.split(':', 1)
-            formatted_lines.append(f'    {key.strip()}')
-            formatted_lines.append(f'        {value.strip()}')
-        formatted_lines.append('')
+        if line.strip() == "":
+            continue
+        deindented_line = line[base_indentation:]
+        if not deindented_line[0].isspace():
+            kwarg_parameter, kwarg_description = deindented_line.split(':', 1)
+            formatted_lines.append(f'{kwarg_param_indent}**{kwarg_parameter.strip()}** - {kwarg_description.strip()}')
+            formatted_lines.append('')
+        else: 
+            formatted_lines[-2] += (f' {deindented_line.strip()}')
 
     return formatted_lines
+
+def line_has_indentation(line):
+    return len(line.lstrip()) != len(line)
+
+

--- a/docs/kwargs_formatter.py
+++ b/docs/kwargs_formatter.py
@@ -22,9 +22,12 @@ def format_kwargs(lines):
             if in_kwargs and kwargs_items:
                 formatted_lines.append('')  # Add a blank line
                 for item in kwargs_items:
-                    key, value = item.split(':', 1)
-                    formatted_lines.append(f'    {key.strip()} - {value.strip()}')
-                    formatted_lines.append('')
+                    if ":" in item:
+                        key, value = item.split(':', 1)
+                        formatted_lines.append(f'    *{key.strip()}* - {value.strip()}')
+                        formatted_lines.append('')
+                    else:
+                        formatted_lines[-2] = formatted_lines[-2] + f' {item}'
                 formatted_lines.append('')
                 kwargs_items = []
             in_kwargs = False

--- a/references.rst
+++ b/references.rst
@@ -1,4 +1,5 @@
-.. _references: 
+.. _references:
+
 
 References
 ==========
@@ -34,152 +35,9 @@ References
 
 **A**
 
-.. [BKW19]  \Andreas Björklund, Petteri Kaski, and Ryan Williams.
-            *Solving Systems of Polynomial Equations over GF(2) by a Parity-Counting Self-Reduction*
-            https://drops.dagstuhl.de/opus/volltexte/2019/10602/pdf/LIPIcs-ICALP-2019-26.pdf
-
-.. [JV18] \Antoine Joux and Vanessa Vitse.
-          *A Crossbred Algorithm for Solving Boolean Polynomial Systems*
-          https://link.springer.com/chapter/10.1007/978-3-319-76620-1_1
-
-.. [ES23] \Andre Esser and Paolo Santini.
-            *Not Just Regular Decoding: Asymptotics and Improvements of Regular Syndrome Decoding Attacks*
-            https://eprint.iacr.org/2023/1568
-
-.. [KPG99] \Aviad Kipnis, Jacques Patarin, and Louis Goubin.
-            *Unbalanced  Oil  and Vinegar Signature Schemes*
-            https://link.springer.com/chapter/10.1007/3-540-48910-X_15
-
-.. [BBPS20] \Alessandro Barenghi, Jean-Francois Biasse, Edoardo Persichetti and Paolo Santini.
-            *{LESS-FM:} Fine-Tuning Signatures from the Code Equivalence Problem*
-            https://doi.org/10.1007/978-3-030-81293-5\_2
-
-.. [EZ23] \Andre Esser and Floyd Zweydinger.
-            *New Time-Memory Trade-Offs for Subset Sum -- Improving ISD in Theory and Practice*
-            https://eprint.iacr.org/2022/1329.pdf
-
-.. [EB22] \Andre Esser and Emanuele Bellini.
-            *Syndrome Decoding Estimator*
-            https://eprint.iacr.org/2021/1243.pdf
-
-.. [MO15] \Alexander May and Ilya Ozerov.
-           *On computing nearest neighbors with applications to decoding of binary linear codes*
-           https://link.springer.com/chapter/10.1007/978-3-662-46800-5_9
-
-.. [MMT11] \Alexander May, Alexander Meurer and Enrico Thomae.
-            *Decoding random linear codes in  2^(0.054n)*
-            https://link.springer.com/chapter/10.1007/978-3-642-25385-0_6
-
-.. [BJMM12] \Anja Becker, Antoine Joux, Alexander May and Alexander Meurer.
-            *Decoding random binary linear codes in 2^(n/20): How 1+ 1= 0 improves information set decoding*
-            https://eprint.iacr.org/2012/026.pdf
 .. _ref-B:
 
 **B**
-
-.. _ref-C:
-
-**C**
-
-.. [Pet11]  \Christiane Peters: Information-set decoding for linear codes over Fq.
-                https://link.springer.com/chapter/10.1007/978-3-642-12929-2_7
-
-.. [BCCCNSY10]  \Charles Bouillaguet, Hsieh-Chung Chen, Chen-Mou Cheng, Tung Chou, Ruben Niederhagen, Adi Shamir, and Bo-Yin Yang.
-                *Fast Exhaustive Search for Polynomial Systems in F_2* https://www.iacr.org/archive/ches2010/62250195/62250195.pdf
-
-.. _ref-D:
-
-**D**
-
-.. [BLP08] Daniel J. Bernstein and Tanja Lange and Christiane Peters
-           *Attacking and Defending the McEliece Cryptosystem*
-           https://link.springer.com/chapter/10.1007/978-3-540-88403-3_3
-
-.. [BLP11] Daniel J. Bernstein and Tanja Lange and Christiane Peters
-           *Smaller decoding exponents: ball-collision decoding*
-           https://link.springer.com/chapter/10.1007/978-3-642-22792-9_42
-
-.. [LPTWY17] \Daniel Lokshtanov, Ramamohan Paturi, Suguru Tamaki, Ryan Williams, and Huacheng Yu.
-            *Beating Brute Force for Systems of Polynomial Equation over Finite Fields*
-            https://people.csail.mit.edu/rrw/polyEqSoda2017Submit.pdf
-
-.. _ref-E:
-
-**E**
-
-.. [CCJ23] \Eliana Carozza, Geoffroy Couteau, and Antoine Joux
-            *Short Signatures from Regular Syndrome Decoding in the Head*, EUROCRYPT 2023
-            https://eprint.iacr.org/2023/1035
-
-.. [KMP19] \Eliane Koussa, Gilles Macario{-}Rat and Jacques Patarin.
-            *On the complexity of the Permuted Kernel Problem*
-            https://eprint.iacr.org/2019/412.pdf
-
-.. [Pra62] \Eugene Prange.
-            *The use of information sets in decoding cyclic codes*
-            https://doi.org/10.1109/TIT.1962.1057777
-
-.. _ref-F:
-
-**F**
-
-.. _ref-G:
-
-**G**
-
-.. _ref-H:
-
-**H**
-
-.. [MHT13]  \Hiroyuki Miura, Yasufumi Hashimoto, and Tsuyoshi Takagi.
-            *Extended Algorithm for Solving Underdefined Multivariate Quadratic Equations*
-            https://link.springer.com/chapter/10.1007/978-3-642-38616-9_8
-
-.. [FNT21] \Hiroki Furue, Shuhei Nakamura, Tsuyoshi Takagi.
-           *Improving Thomae-Wolf Algorithm for Solving Underdetermined Multivariate Quadratic Polynomial Problem*
-           https://dl.acm.org/doi/10.1007/978-3-030-81293-5_4
-
-.. _ref-I:
-
-**I**
-
-.. [Dum91] \Ilya Dumer.
-            *On minimum distance decoding of linear codes*
-
-.. [Din21a] \Itai Dinur.
-            *Improved Algorithms for Solving Polynomial Systems over GF(2) by Multiple Parity-Counting*
-            https://arxiv.org/pdf/2005.04800.pdf
-
-.. [Din21b] \Itai Dinur.
-            *Cryptanalytic Applications of the Polynomial Method for Solving Multivariate Equation Systems over GF(2)*
-            https://eprint.iacr.org/2021/578.pdf
-
-.. _ref-J:
-
-**J**
-
-.. \John Baena, Pierre Briaud, Daniel Cabarcas, Ray Perlner, Daniel Smith-Tone and Javier Verbel.
-   *Improving Support-Minors rank attacks: applications to GeMSS and Rainbow*
-   https://eprint.iacr.org/2021/1677.pdf
-
-.. [Ste88] \Jacques Stern.
-            *A method for finding codewords of small weight*
-            https://doi.org/10.1007/BFb0019850
-
-.. [Dua20] \João Diogo Duarte.
-            *On the Complexity of the Crossbred Algorithm*
-
-.. [Leo82] \Jeffrey S. Leon.
-            *Computing automorphism groups of error-correcting codes*
-            https://doi.org/10.1109/TIT.1982.1056498
-
-.. _ref-K:
-
-**K**
-
-.. _ref-L:
-
-**L**
 
 .. [BFP09] \Luk Bettale, Jean-Charles Faugère and Ludovic Perret.
            *Hybrid Approach for Solving Multivariate Systems over Finite Fields*
@@ -189,33 +47,180 @@ References
            *Solving Polynomial Systems over Finite Fields: Improved Analysis of the Hybrid Approach*
            https://doi.org/10.1145/2442829.2442843
 
-.. [BM18] \Leif Both and Alexander May.
-           *Decoding Linear Codes with High Error Rate and its Impact for LPN Security*
-           https://eprint.iacr.org/2017/1139.pdf
+.. [BCCHK23] \Ward Beullens, Fabio Campos, Sofía Celi, Basil Hess, and Matthias J. Kannwischer.
+             *MAYO: Specifications*
+             https://pqmayo.org/assets/specs/mayo.pdf
 
-.. _ref-M:
+.. [Beu20] \Ward Beullens.
+           *Not Enough LESS: An Improved Algorithm for Solving Code Equivalence Problems over Fq*
+           https://doi.org/10.1007/978-3-030-81652-0_15
 
-**M**
+.. [BBCPSTV22] \John Baena, Pierre Briaud, Daniel Cabarcas, Ray Perlner, Daniel Smith-Tone, and Javier Verbel.
+                *Improving Support-Minors rank attacks: applications to GeMSS and Rainbow*
+                https://eprint.iacr.org/2021/1677.pdf
+
+.. [BBPS20] \Alessandro Barenghi, Jean-Francois Biasse, Edoardo Persichetti and Paolo Santini.
+            *{LESS-FM:} Fine-Tuning Signatures from the Code Equivalence Problem*
+            https://doi.org/10.1007/978-3-030-81293-5\_2
+
+.. [BKW19]  \Andreas Björklund, Petteri Kaski, and Ryan Williams.
+            *Solving Systems of Polynomial Equations over GF(2) by a Parity-Counting Self-Reduction*
+            https://drops.dagstuhl.de/opus/volltexte/2019/10602/pdf/LIPIcs-ICALP-2019-26.pdf
 
 .. [BFSS11] \Magali Bardet, Jean-Charles Faugère, Bruno Salvy, and Pierre-Jean Spaenlehauer.
             *On the Complexity of Solving Quadratic Boolean Systems*
             https://www.sciencedirect.com/science/article/pii/S0885064X12000611
 
-.. _ref-N:
+.. [BCCCNSY10]  \Charles Bouillaguet, Hsieh-Chung Chen, Chen-Mou Cheng, Tung Chou, Ruben Niederhagen, Adi Shamir, and Bo-Yin Yang.
+                *Fast Exhaustive Search for Polynomial Systems in F_2*
+                https://www.iacr.org/archive/ches2010/62250195/62250195.pdf
 
-**N**
+.. [BLP11] \Daniel J. Bernstein and Tanja Lange and Christiane Peters
+           *Smaller decoding exponents: ball-collision decoding*
+           https://link.springer.com/chapter/10.1007/978-3-642-22792-9_42
 
-.. [CKPS]   \Nicolas Courtois, Alexander Klimov, Jacques Patarin, and Adi Shamir.
-            *Efficient Algorithms for Solving Overdefined Systems of Multivariate Polynomial Equations*
-            https://www.iacr.org/archive/eurocrypt2000/1807/18070398-new.pdf
+.. [BJMM12] \Anja Becker, Antoine Joux, Alexander May and Alexander Meurer.
+            *Decoding random binary linear codes in 2^(n/20): How 1+ 1= 0 improves information set decoding*
+            https://eprint.iacr.org/2012/026.pdf
+
+.. [BM18] \Leif Both and Alexander May.
+           *Decoding Linear Codes with High Error Rate and its Impact for LPN Security*
+           https://eprint.iacr.org/2017/1139.pdf
+
+.. [BLP08] Daniel J. Bernstein and Tanja Lange and Christiane Peters
+           *Attacking and Defending the McEliece Cryptosystem*
+           https://link.springer.com/chapter/10.1007/978-3-540-88403-3_3
+
+
+.. _ref-C:
+
+**C**
+
+.. [CCJ23] \Eliana Carozza, Geoffroy Couteau, and Antoine Joux.
+           *Short Signatures from Regular Syndrome Decoding in the Head*, EUROCRYPT 2023
+           https://eprint.iacr.org/2023/1035
 
 .. [CGMT02] \Nicolas Courtois, Louis Goubin, Willi Meier, and Jean-Daniel Tacier.
             *Solving Underdefined Systems of Multivariate Quadratic Equations*
             https://link.springer.com/chapter/10.1007/3-540-45664-3_15
 
-.. [Sen06] \Nicolas Sendrier
-            *The Support Splitting Algorithm*
-            https://hal.inria.fr/inria-00073037/document
+.. [CKPS] \Nicolas Courtois, Alexander Klimov, Jacques Patarin, and Adi Shamir.
+          *Efficient Algorithms for Solving Overdefined Systems of Multivariate Polynomial Equations*
+          https://www.iacr.org/archive/eurocrypt2000/1807/18070398-new.pdf
+
+.. _ref-D:
+
+**D**
+
+.. [Dua20] \João Diogo Duarte.
+           *On the Complexity of the Crossbred Algorithm*
+
+.. [Dum91] \Ilya Dumer.
+           *On minimum distance decoding of linear codes*
+
+.. [Din21a] \Itai Dinur.
+                *Improved Algorithms for Solving Polynomial Systems over GF(2) by Multiple Parity-Counting*
+                https://arxiv.org/pdf/2005.04800.pdf
+
+.. [Din21b] \Itai Dinur.
+                *Cryptanalytic Applications of the Polynomial Method for Solving Multivariate Equation Systems over GF(2)*
+                https://eprint.iacr.org/2021/578.pdf
+
+.. _ref-E:
+
+**E**
+
+.. [ES23] \Andre Esser and Paolo Santini.
+          *Not Just Regular Decoding: Asymptotics and Improvements of Regular Syndrome Decoding Attacks*
+          https://eprint.iacr.org/2023/1568
+
+.. [EB22] \Andre Esser and Emanuele Bellini.
+          *Syndrome Decoding Estimator*
+          https://eprint.iacr.org/2021/1243.pdf
+
+.. [EZ23] \Andre Esser and Floyd Zweydinger.
+          *New Time-Memory Trade-Offs for Subset Sum -- Improving ISD in Theory and Practice*
+          https://eprint.iacr.org/2022/1329.pdf
+
+.. _ref-F:
+
+**F**
+
+.. [FNT21] \Hiroki Furue, Shuhei Nakamura, Tsuyoshi Takagi.
+           *Improving Thomae-Wolf Algorithm for Solving Underdetermined Multivariate Quadratic Polynomial Problem*
+           https://dl.acm.org/doi/10.1007/978-3-030-81293-5_4
+
+.. _ref-G:
+
+**G**
+
+.. _ref-H:
+
+**H**
+
+.. [MHT13] \Hiroyuki Miura, Yasufumi Hashimoto, and Tsuyoshi Takagi.
+           *Extended Algorithm for Solving Underdefined Multivariate Quadratic Equations*
+           https://link.springer.com/chapter/10.1007/978-3-642-38616-9_8
+
+.. _ref-I:
+
+**I**
+
+.. _ref-J:
+
+**J**
+
+.. [JV18] \Antoine Joux and Vanessa Vitse.
+                *A Crossbred Algorithm for Solving Boolean Polynomial Systems*
+                https://link.springer.com/chapter/10.1007/978-3-319-76620-1_1
+
+
+.. _ref-K:
+
+**K**
+
+.. [KPG99] \Aviad Kipnis, Jacques Patarin, and Louis Goubin.
+            *Unbalanced  Oil  and Vinegar Signature Schemes*
+            https://link.springer.com/chapter/10.1007/3-540-48910-X_15
+
+.. [KMP19] \Eliane Koussa, Gilles Macario{-}Rat and Jacques Patarin.
+            *On the complexity of the Permuted Kernel Problem*
+            https://eprint.iacr.org/2019/412.pdf
+
+
+.. _ref-L:
+
+**L**
+
+.. [LB88] \Pil Joong Lee and Ernest Brickell.
+                *An Observation on the Security of McEliece’s Public-Key Cryptosystem*
+                https://doi.org/10.1007/3-540-45961-8_25
+
+.. [Leo82] \Jeffrey S. Leon.
+            *Computing automorphism groups of error-correcting codes*
+            https://doi.org/10.1109/TIT.1982.1056498
+
+.. [LPTWY17] \Daniel Lokshtanov, Ramamohan Paturi, Suguru Tamaki, Ryan Williams, and Huacheng Yu.
+            *Beating Brute Force for Systems of Polynomial Equation over Finite Fields*
+            https://people.csail.mit.edu/rrw/polyEqSoda2017Submit.pdf
+
+
+
+.. _ref-M:
+
+**M**
+
+.. [MMT11] \Alexander May, Alexander Meurer, and Enrico Thomae.
+                *Decoding Random Linear Codes in 2^(0.054n)*
+                https://link.springer.com/chapter/10.1007/978-3-642-25385-0_6
+
+.. [MO15] \Alexander May and Ilya Ozerov.
+                *On Computing Nearest Neighbors with Applications to Decoding of Binary Linear Codes*
+                https://link.springer.com/chapter/10.1007/978-3-662-46800-5_9
+
+.. _ref-N:
+
+**N**
 
 .. _ref-O:
 
@@ -225,14 +230,13 @@ References
 
 **P**
 
+.. [Pra62] \Eugene Prange.
+                *The Use of Information Sets in Decoding Cyclic Codes*
+                https://doi.org/10.1109/TIT.1962.1057777
 
-.. [LB88] \Pil Joong Lee and Ernest Brickell.
-           *An observation on the security of McEliece’s public-key cryptosystem*
-           https://doi.org/10.1007/3-540-45961-8\_25
-
-.. [SBC22] \Paolo Santini, Marco Baldi, and Franco Chiaraluce
-            *Computational Hardness of the Permuted Kernel and Subcode Equivalence Problems*
-            https://eprint.iacr.org/2022/1749.pdf
+.. [Pet11]  \Christiane Peters.
+            *Information-set decoding for linear codes over Fq*
+            https://link.springer.com/chapter/10.1007/978-3-642-12929-2_7
 
 .. _ref-Q:
 
@@ -246,9 +250,25 @@ References
 
 **S**
 
+.. [SBC22] \Paolo Santini, Marco Baldi, and Franco Chiaraluce.
+            *Computational Hardness of the Permuted Kernel and Subcode Equivalence Problems*
+            https://eprint.iacr.org/2022/1749.pdf
+
+.. [Sen06] \Nicolas Sendrier.
+           *The Support Splitting Algorithm*
+           https://hal.inria.fr/inria-00073037/document
+
+.. [Ste88] \Jacques Stern.
+            *A method for finding codewords of small weight*
+            https://doi.org/10.1007/BFb0019850
+
 .. _ref-T:
 
 **T**
+
+.. [TW12] \Enrico Thomae and Christopher Wolf.
+                *Solving Underdetermined Systems of Multivariate Quadratic Equations Revisited*
+                https://doi.org/10.1007/978-3-642-30057-8_10
 
 .. _ref-U:
 
@@ -261,14 +281,6 @@ References
 .. _ref-W:
 
 **W**
-
-.. [Beu20] \Ward Beullens.
-            *Not enough LESS: An improved algorithm for solving Code Equivalence Problems over Fq*
-            https://doi.org/10.1007/978-3-030-81652-0\_15
-
-.. [BCCHK23] \Ward Beullens, Fabio Campos, Sofı́a Celi, Basil Hess and Matthias J. Kannwischer.
-              *MAYO: Specifications*
-              https://pqmayo.org/assets/specs/mayo.pdf
 
 .. _ref-X:
 

--- a/scripts/create_documentation.py
+++ b/scripts/create_documentation.py
@@ -39,9 +39,9 @@ def header_style(section, level):
 
 
 with Path(SOURCE_ROOT_FOLDER, "index.rst").open(mode="w") as index_rst_file:
-    index_rst_file.write("=========================\n"
+    index_rst_file.write("================================\n"
                          "CryptographicEstimators Library\n"
-                         "=========================\n"
+                         "================================\n"
                          "\n"
                          "This is a sample reference manual for CryptographicEstimators library.\n"
                          "\n"


### PR DESCRIPTION
### Description
This PR fixes the HTML docs generation issues that we are currently having in develop. The issue was coming from this kind of multilined kwargs:

![image](https://github.com/user-attachments/assets/bd09a7d8-5944-444c-88b3-af2149f18526)

I decided to completely rewrite the code to make it more mainteinable and easier to follow. It's also much more robust by supporting as formatting criteria the indentation of the docstring (instead of the content of the lines, as was done before).

The new formatting looks like this:

![image](https://github.com/user-attachments/assets/6ecc2863-acee-4e97-85b7-c0619f38a3dc)

For the following docstring:
```python
        """
        Args:
            problem (MQProblem): MQProblem object including all necessary parameters.
            **kwargs: Additional keyword arguments.
                h (int): External hybridization parameter. Defaults to 0.
                w (float): Linear algebra constant (2 <= w <= 3). Defaults to 2.81.
                max_D (int): Upper bound to the parameter D. Defaults to 20.
                memory_access (int): Specifies the memory access cost model. Defaults to 0.
                    Choices: 0 - constant, 1 - logarithmic, 2 - square-root, 3 - cube-root.
                    Alternatively, deploy a custom function which takes as input the logarithm
                    of the total memory usage.
                complexity_type (int): Complexity type to consider. Defaults to 0.
                    0: estimate, 1: tilde O complexity.
       """
```

### Review process
- Take a look at the new code and let me know if it's easy to follow or not.
- Try to generate the documentation with `make docker-doc` (installation free, docker required)
- Try to generate the documentation with `make doc` (after installing, no docker required)

### Pre-approval checklist
- [x] The code builds clean without any errors or warnings
- [ ] I've added/updated tests
- [x] I've added/updated documentation if needed
