### PR TITLE
Refactor/improve kat test prompting on fail

### DIFF
--- a/tests/test_kat.py
+++ b/tests/test_kat.py
@@ -107,7 +107,7 @@ def test_all_estimators(kat: dict):
         inputs, expected_outputs = zip(*inputs_with_outputs)
         internal_estimator_function = import_internal_estimator(internal_estimator_path)
         actual_outputs, epsilon = zip(*map(internal_estimator_function, inputs))
-        internal_estimator_name = internal_estimator_path[-1]
+        internal_estimator_name = f"{internal_estimator_path[-1]} from {internal_estimator_path[-2].upper()}Estimator"
 
         execution_list.extend(
             list(


### PR DESCRIPTION
### Description
Improve message description on failed KAT test execution by providing the failing function name and the estimator.


### Review process

This comes from the fact that we have two bulleans KAT, one for LEEstimator and other for PEEstimator. On failing, this can be hard to debug without knowing from where the results are coming.

### Pre-approval checklist
- [ ] The code builds clean without any errors or warnings
- [ ] I've added/updated tests
- [ ] I've added/updated documentation if needed
