### PR TITLE
Update user_guide for Binary Syndrome Decoding Estimator

### DIFF
--- a/docs/github/user_guide.md
+++ b/docs/github/user_guide.md
@@ -47,7 +47,7 @@ The following code creates an estimator of the SD problem with code length $n =
 
 ```python
 from cryptographic_estimators.SDEstimator import SDEstimator
-SDE = SDEstimator(n=20, k=10, w=10)
+SDE = SDEstimator(n=100, k=50, w=10)
 ```
 
 The following code creates an estimator of the MQ problem $n = 15$ variables and


### PR DESCRIPTION

### Description

In the below picture, I mention screenshot of code while running [CryptographicEstimators](https://estimators.crypto.tii.ae/) 
For "Binary Syndrome Decoding Estimator," for values n = 20, k = 10, and w = 10, which are mentioned in user_guide it shows "Math domain error.".

![Picture-> CryptographicEstimators Output](https://github.com/user-attachments/assets/08fe3a42-54df-45f8-bab8-e5bd009071c9)

### Review process
- When I saw code, then I read in the above line that they mention they are running for n = 100, k = 50, and w = 10, but they are in code running n = 20, k = 10, and w = 10, so I think code is not compatible for those parameters. 

- So I modify that command for n = 20, k = 10, w = 10, to n = 100, k = 50, w = 10. (below I mention codesnipit.)
 
![Picture->Error Code Picture](https://github.com/user-attachments/assets/f3783ad8-3c1a-4170-9f90-fb47fd8df93a)

)
