### PR TITLE
Feature/Add Sage testing Dockerfile

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,0 +1,13 @@
+FROM sagemath/sagemath
+WORKDIR "/home/cryptographic_estimators/"
+
+# Sage base image is very restrictive without sudo
+USER root
+
+# Install the library in development mode
+COPY . .
+RUN sage -pip install -e .
+
+# Restore normal user
+USER sage
+

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -4,10 +4,9 @@ WORKDIR "/home/cryptographic_estimators/"
 # Sage base image is very restrictive without sudo
 USER root
 
+# Set Python path to include project root
+ENV PYTHONPATH=/home/cryptographic_estimators
+
 # Install the library in development mode
 COPY . .
 RUN sage -pip install -e .
-
-# Restore normal user
-USER sage
-


### PR DESCRIPTION
### Description

Implementation of the new Sage Dockerfile for KAT generation and exploration purposes, without any relation with our CI.

I've updated our Makefile adding 4 commands:

- `docker-sage-build`
- `docker-sage-repl`: Launch a Sage REPL with the library already installed in it.
- `docker-sage-shell`: Opens an interactive shell (sh) within the Sage container.
- `docker-sage-generate-kat`: Generate Known Answer Test (KAT) values.


Closes https://github.com/Crypto-TII/CryptographicEstimators/issues/256.

### Review process
- Take a look to the new Dockerfile
- Test each one of the new commands (the generate KAT will take some time; you could remove some of the `ext_<estimator>` files to speed up the process)

I will update our docs once @Javierverbel refactor of the `tests` directory gets merged.

### Pre-approval checklist
- [x] The code builds clean without any errors or warnings
- [x] I've added/updated tests
- [ ] I've added/updated documentation if needed
