### PR TITLE
Fix/regsd solution density

### DIFF
--- a/cryptographic_estimators/RegSDEstimator/RegSDAlgorithms/regisd_enum.py
+++ b/cryptographic_estimators/RegSDEstimator/RegSDAlgorithms/regisd_enum.py
@@ -126,5 +126,5 @@ class RegularISDEnum(RegSDAlgorithm):
         T_iter = max(log2(n - k_prime) * 2, 1 + L, L * 2 - ell)
 
         # overall cost
-        time = T_iter - p_iter
+        time = self._time_with_repetitions(T_iter, p_iter)
         return time, L

--- a/cryptographic_estimators/RegSDEstimator/RegSDAlgorithms/regisd_perm.py
+++ b/cryptographic_estimators/RegSDEstimator/RegSDAlgorithms/regisd_perm.py
@@ -57,7 +57,7 @@ class RegularISDPerm(RegSDAlgorithm):
         # cost of one iteration
         T_iter = log2(n - k_prime) * 2
 
-        return T_iter - p_iter
+        return self._time_with_repetitions(T_iter, p_iter)
 
     def _compute_memory_complexity(self, parameters: dict):
         """Return the memory complexity of the algorithm for a given set of parameters.

--- a/cryptographic_estimators/RegSDEstimator/RegSDAlgorithms/regisd_rep.py
+++ b/cryptographic_estimators/RegSDEstimator/RegSDAlgorithms/regisd_rep.py
@@ -180,7 +180,6 @@ class RegularISDRep(RegSDAlgorithm):
         T_iter = max(T_gauss, 3 + L1, 2 + L_y1, 1 + N_y, 1 + L_x1, N_x)
 
         # overall cost
-        time = T_iter - p_iter
+        time = self._time_with_repetitions(T_iter, p_iter)
         memory = max(L1, L_y1,L_x1)
         return time, memory
-

--- a/cryptographic_estimators/RegSDEstimator/regsd_algorithm.py
+++ b/cryptographic_estimators/RegSDEstimator/regsd_algorithm.py
@@ -55,3 +55,10 @@ class RegSDAlgorithm(BaseAlgorithm):
             parameters (dict): Dictionary including the parameters.
         """
         return self._compute_time_and_memory_complexity(parameters)[1]
+
+    def _time_with_repetitions(self, iteration_time: float, log2_single_solution_success_probability: float):
+        """Return total time after accounting for repeated trials and multiple solutions."""
+        repetitions = max(
+            -log2_single_solution_success_probability - self.problem.nsolutions, 0
+        )
+        return iteration_time + repetitions


### PR DESCRIPTION
 ### Description
  - Account for the expected number of RegSD solutions when computing repeated-trial time (`q_iter`) for RegularISDPerm,
  RegularISDEnum, and RegularISDRep.
  - The solution density is taken from `problem.nsolutions`.

  - Check that the three regular ISD algorithms use it for their total time estimate.
  - Verify small testing examples.

  ### Pre-approval checklist
  - [x] The code builds clean without any errors or warnings
